### PR TITLE
fix(crash): handle scaleway crashing bc of invalid JSON

### DIFF
--- a/scaleway/helpers.go
+++ b/scaleway/helpers.go
@@ -94,7 +94,10 @@ func waitForServerState(scaleway *api.ScalewayAPI, serverID, targetState string)
 				}
 			}
 
-			return 42, s.State, err
+			if s != nil {
+				return 42, s.State, err
+			}
+			return 42, "error", err
 		},
 		Timeout:    60 * time.Minute,
 		MinTimeout: 5 * time.Second,


### PR DESCRIPTION
closes #4 - when Scaleway returns invalid JSON the terraform provider crashed bc/ the assumption was that a server is always returned - which in this case isn't.