### PR TITLE
chore(provider) basic sweeper implementation

### DIFF
--- a/scaleway/resource_scaleway_volume_attachment.go
+++ b/scaleway/resource_scaleway_volume_attachment.go
@@ -10,36 +10,6 @@ import (
 	"github.com/scaleway/scaleway-cli/pkg/api"
 )
 
-func init() {
-	resource.AddTestSweepers("scaleway_volume", &resource.Sweeper{
-		Name: "scaleway_volume",
-		F:    testSweepVolume,
-	})
-}
-
-func testSweepVolume(region string) error {
-	client, err := sharedClientForRegion(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-
-	scaleway := client.(*Client).scaleway
-	log.Printf("[DEBUG] Destroying the volumes in (%s)", region)
-
-	volumes, err := scaleway.GetVolumes()
-	if err != nil {
-		return fmt.Errorf("Error describing volumes in Sweeper: %s", err)
-	}
-
-	for _, volume := range *volumes {
-		if err := scaleway.DeleteVolume(volume.Identifier); err != nil {
-			return fmt.Errorf("Error deleting volume in Sweeper: %s", err)
-		}
-	}
-
-	return nil
-}
-
 func resourceScalewayVolumeAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceScalewayVolumeAttachmentCreate,

--- a/scaleway/resource_scaleway_volume_attachment.go
+++ b/scaleway/resource_scaleway_volume_attachment.go
@@ -10,6 +10,36 @@ import (
 	"github.com/scaleway/scaleway-cli/pkg/api"
 )
 
+func init() {
+	resource.AddTestSweepers("scaleway_volume", &resource.Sweeper{
+		Name: "scaleway_volume",
+		F:    testSweepVolume,
+	})
+}
+
+func testSweepVolume(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	scaleway := client.(*Client).scaleway
+	log.Printf("[DEBUG] Destroying the volumes in (%s)", region)
+
+	volumes, err := scaleway.GetVolumes()
+	if err != nil {
+		return fmt.Errorf("Error describing volumes in Sweeper: %s", err)
+	}
+
+	for _, volume := range *volumes {
+		if err := scaleway.DeleteVolume(volume.Identifier); err != nil {
+			return fmt.Errorf("Error deleting volume in Sweeper: %s", err)
+		}
+	}
+
+	return nil
+}
+
 func resourceScalewayVolumeAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceScalewayVolumeAttachmentCreate,

--- a/scaleway/resource_scaleway_volume_test.go
+++ b/scaleway/resource_scaleway_volume_test.go
@@ -2,11 +2,42 @@ package scaleway
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("scaleway_volume", &resource.Sweeper{
+		Name: "scaleway_volume",
+		F:    testSweepVolume,
+	})
+}
+
+func testSweepVolume(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	scaleway := client.(*Client).scaleway
+	log.Printf("[DEBUG] Destroying the volumes in (%s)", region)
+
+	volumes, err := scaleway.GetVolumes()
+	if err != nil {
+		return fmt.Errorf("Error describing volumes in Sweeper: %s", err)
+	}
+
+	for _, volume := range *volumes {
+		if err := scaleway.DeleteVolume(volume.Identifier); err != nil {
+			return fmt.Errorf("Error deleting volume in Sweeper: %s", err)
+		}
+	}
+
+	return nil
+}
 
 func TestAccScalewayVolume_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/scaleway/scaleway_sweeper_test.go
+++ b/scaleway/scaleway_sweeper_test.go
@@ -1,0 +1,39 @@
+package scaleway
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+// sharedClientForRegion returns a common scaleway client needed for the sweeper
+// functions for a given region {par1,ams1}
+func sharedClientForRegion(region string) (interface{}, error) {
+	if os.Getenv("SCALEWAY_ORGANIZATION") == "" {
+		return nil, fmt.Errorf("empty SCALEWAY_ORGANIZATION")
+	}
+
+	if os.Getenv("SCALEWAY_ACCESS_KEY") == "" {
+		return nil, fmt.Errorf("empty SCALEWAY_ACCESS_KEY")
+	}
+
+	conf := &Config{
+		Organization: os.Getenv("SCALEWAY_ORGANIZATION"),
+		APIKey:       os.Getenv("SCALEWAY_ACCESS_KEY"),
+		Region:       region,
+	}
+
+	// configures a default client for the region, using the above env vars
+	client, err := conf.Client()
+	if err != nil {
+		return nil, fmt.Errorf("error getting Scaleway client")
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
\cc @stack72. thanks for pointing me at the AWS provider, man!

```
go test . -v -sweep=par1
2017/06/19 19:18:55 [DEBUG] Running Sweepers for region (par1):
2017/06/19 19:18:55 [DEBUG] Destroying the volumes in (par1)
2017/06/19 19:18:55 [DEBUG] HEAD /volumes
2017/06/19 19:18:55 [DEBUG] [[HEAD https://cp-par1.scaleway.com/volumes?]]: %!v(MISSING)
2017/06/19 19:18:55 [DEBUG] GET /volumes
2017/06/19 19:18:55 [DEBUG] [[GET https://cp-par1.scaleway.com/volumes]]: %!v(MISSING)
2017/06/19 19:18:55 [DEBUG] [Response]: [[200 {"volumes": []}]]
%!v(MISSING)
2017/06/19 19:18:55 [DEBUG] Destroying the ips in (par1)
2017/06/19 19:18:55 [DEBUG] HEAD /ips
2017/06/19 19:18:55 [DEBUG] [[HEAD https://cp-par1.scaleway.com/ips?]]: %!v(MISSING)
2017/06/19 19:18:55 [DEBUG] GET /ips
2017/06/19 19:18:55 [DEBUG] [[GET https://cp-par1.scaleway.com/ips]]: %!v(MISSING)
2017/06/19 19:18:55 [DEBUG] [Response]: [[200 {"ips": []}]]
%!v(MISSING)
2017/06/19 19:18:55 [DEBUG] Destroying the security groups in (par1)
2017/06/19 19:18:55 [DEBUG] HEAD /security_groups
2017/06/19 19:18:55 [DEBUG] [[HEAD https://cp-par1.scaleway.com/security_groups?]]: %!v(MISSING)
2017/06/19 19:18:55 [DEBUG] GET /security_groups
2017/06/19 19:18:55 [DEBUG] [[GET https://cp-par1.scaleway.com/security_groups]]: %!v(MISSING)
2017/06/19 19:18:56 [DEBUG] [Response]: [[200 {"security_groups": [{"description": "Auto generated security group.", "enable_default_security": true, "servers": [], "organization": "7b4c2f27-067d-4a79-b721-1aaac4475889", "organization_default": true, "id": "4e89dc74-556e-41da-bafd-86bfecfc53f7", "name": "Default security group"}]}]]
%!v(MISSING)
2017/06/19 19:18:56 [DEBUG] Destroying the servers in (par1)
2017/06/19 19:18:56 [DEBUG] HEAD /servers
2017/06/19 19:18:56 [DEBUG] HEAD /servers
2017/06/19 19:18:56 [DEBUG] [[HEAD https://cp-ams1.scaleway.com/servers?]]: %!v(MISSING)
2017/06/19 19:18:56 [DEBUG] [[HEAD https://cp-par1.scaleway.com/servers?]]: %!v(MISSING)
2017/06/19 19:18:56 [DEBUG] GET /servers
2017/06/19 19:18:56 [DEBUG] [[GET https://cp-par1.scaleway.com/servers]]: %!v(MISSING)
2017/06/19 19:18:56 [DEBUG] [Response]: [[200 {"servers": []}]]
%!v(MISSING)
2017/06/19 19:18:57 [DEBUG] GET /servers
2017/06/19 19:18:57 [DEBUG] [[GET https://cp-ams1.scaleway.com/servers]]: %!v(MISSING)
2017/06/19 19:18:57 [DEBUG] [Response]: [[200 {"servers": []}]]
%!v(MISSING)
2017/06/19 19:18:57 Sweeper Tests ran:
	- scaleway_volume
	- scaleway_ip
	- scaleway_security_group
	- scaleway_server
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	2.828s
```