### PR TITLE
fix(volume_attachment): fix volume_attachment deletion

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -3,7 +3,6 @@ package scaleway
 import (
 	"sync"
 
-	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -61,8 +60,6 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 	}
 }
-
-var scalewayMutexKV = mutexkv.NewMutexKV()
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	apiKey := ""


### PR DESCRIPTION
4a153c47beda7abd8b061aebca1e295974f975cc introduced a deadlock caused my
duplicated calls to `mu.Lock()` in a function as well as inside a
`resource.Retry` closure.

fixes #3

```
--- PASS: TestAccScalewayVolumeAttachment_Basic (452.97s)
PASS
```