### PR TITLE
add zero sized volumes to scaleway_server

### DIFF
--- a/scaleway/helpers.go
+++ b/scaleway/helpers.go
@@ -26,14 +26,6 @@ func validateVolumeType(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validateVolumeSize(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	if value < 1 || value > 150 {
-		errors = append(errors, fmt.Errorf("%q be more than 1 and less than 150", k))
-	}
-	return
-}
-
 // deleteRunningServer terminates the server and waits until it is removed.
 func deleteRunningServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) error {
 	err := scaleway.PostServerAction(server.Identifier, "terminate")

--- a/scaleway/resource_server_test.go
+++ b/scaleway/resource_server_test.go
@@ -112,19 +112,23 @@ func TestAccScalewayServer_Volumes(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "type", "C1"),
 					resource.TestCheckResourceAttr(
-						"scaleway_server.base", "volume.#", "2"),
+						"scaleway_server.base", "volume.#", "3"),
 					resource.TestCheckResourceAttrSet(
 						"scaleway_server.base", "volume.0.volume_id"),
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "volume.0.type", "l_ssd"),
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "volume.0.size_in_gb", "20"),
-					resource.TestCheckResourceAttrSet(
-						"scaleway_server.base", "volume.1.volume_id"),
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "volume.1.type", "l_ssd"),
 					resource.TestCheckResourceAttr(
-						"scaleway_server.base", "volume.1.size_in_gb", "30"),
+						"scaleway_server.base", "volume.1.size_in_gb", "0"),
+					resource.TestCheckResourceAttrSet(
+						"scaleway_server.base", "volume.2.volume_id"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.2.type", "l_ssd"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "volume.2.size_in_gb", "30"),
 				),
 			},
 		},
@@ -338,6 +342,11 @@ resource "scaleway_server" "base" {
 
   volume {
     size_in_gb = 20
+    type = "l_ssd"
+  }
+
+  volume {
+    size_in_gb = 0
     type = "l_ssd"
   }
 

--- a/scaleway/resource_volume.go
+++ b/scaleway/resource_volume.go
@@ -27,10 +27,16 @@ func resourceScalewayVolume() *schema.Resource {
 				Description: "the name of the volume",
 			},
 			"size_in_gb": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validateVolumeSize,
-				Description:  "the size of the volume in GB",
+				Type:     schema.TypeInt,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(int)
+					if value < 1 || value > 150 {
+						errors = append(errors, fmt.Errorf("%q be more than 1 and less than 150", k))
+					}
+					return
+				},
+				Description: "the size of the volume in GB",
 			},
 			"type": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Add support for `volume` with `size_in_gb` of `0` in the `scaleway_server` resource - resolves #19 .

Now, the following terraform code is valid:

```
resource "scaleway_server" "base" {
  name = "test"
  image = "some-guid"
  type = "VC1S"

  volume {
    size_in_gb = 0
    type = "l_ssd"
  }
}
```

previously, this would have errored because the volume size of 0 was disallowed. Now this is valid and it allows for the creation of terraform modules which span all available scaleway instance types.

The tests remain green, as this is only a small behaviour adjustment:

```
make testacc TESTARGS="-run='TestAccScalewayServer'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccScalewayServer' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (128.65s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (123.43s)
=== RUN   TestAccScalewayServer_ExistingIP
--- PASS: TestAccScalewayServer_ExistingIP (105.07s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (143.62s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (133.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	634.434s
``` 