### PR TITLE
fix crash with invalid bootscript filter

### DIFF
--- a/scaleway/data_source_bootscript.go
+++ b/scaleway/data_source_bootscript.go
@@ -87,7 +87,7 @@ func dataSourceScalewayBootscriptRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	var isMatch func(api.ScalewayBootscript) bool
+	isMatch := func(s api.ScalewayBootscript) bool { return true }
 
 	architecture := d.Get("architecture")
 	if name, ok := d.GetOk("name"); ok {


### PR DESCRIPTION
Given a bootscript datasource without proper filter, the existing data source would crash as the `isMatch` variable is not set. See #21 for an example of this.

This PR initializes `isMatch` to a function to ensure this doesn't happen anymore. 