### PR TITLE
best effort commercial server type validation

### DIFF
--- a/scaleway/config.go
+++ b/scaleway/config.go
@@ -1,6 +1,10 @@
 package scaleway
 
-import "github.com/nicolai86/scaleway-sdk/api"
+import (
+	"sort"
+
+	"github.com/nicolai86/scaleway-sdk/api"
+)
 
 // Config contains scaleway configuration values
 type Config struct {
@@ -23,6 +27,14 @@ func (c *Config) Client() (*Client, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// fetch known scaleway server types to support validation in r/server
+	if len(commercialServerTypes) == 0 {
+		if availability, err := api.GetServerAvailabilities(); err == nil {
+			commercialServerTypes = availability.CommercialTypes()
+			sort.StringSlice(commercialServerTypes).Sort()
+		}
 	}
 	return &Client{api}, nil
 }

--- a/scaleway/helpers.go
+++ b/scaleway/helpers.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -16,6 +17,24 @@ func Bool(val bool) *bool {
 // String returns a pointer to of the string value passed in.
 func String(val string) *string {
 	return &val
+}
+
+func validateServerType(v interface{}, k string) (ws []string, errors []error) {
+	// only validate if we were able to fetch a list of commercial types
+	if len(commercialServerTypes) == 0 {
+		return
+	}
+
+	isKnown := false
+	requestedType := v.(string)
+	for _, knownType := range commercialServerTypes {
+		isKnown = isKnown || strings.ToUpper(knownType) == strings.ToUpper(requestedType)
+	}
+
+	if !isKnown {
+		errors = append(errors, fmt.Errorf("%q must be one of %q", k, commercialServerTypes))
+	}
+	return
 }
 
 func validateVolumeType(v interface{}, k string) (ws []string, errors []error) {

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -8,6 +8,8 @@ import (
 	"github.com/nicolai86/scaleway-sdk/api"
 )
 
+var commercialServerTypes []string
+
 func resourceScalewayServer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceScalewayServerCreate,
@@ -31,10 +33,11 @@ func resourceScalewayServer() *schema.Resource {
 				Description: "The base image of the server",
 			},
 			"type": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The instance type of the server",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The instance type of the server",
+				ValidateFunc: validateServerType,
 			},
 			"bootscript": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
fetch the list of known server types on initialization and cache it to validate r/server types later.

closes #17

all server-related tests remain green with this change:

```
make testacc TESTARGS="-run='TestAccScalewayServer_'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccScalewayServer_' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (91.70s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (96.95s)
=== RUN   TestAccScalewayServer_ExistingIP
--- PASS: TestAccScalewayServer_ExistingIP (88.13s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (105.94s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (124.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	506.928s
```