### PR TITLE
improve scaleway SDK to return created SG rule

### DIFF
--- a/scaleway/resource_security_group_rule.go
+++ b/scaleway/resource_security_group_rule.go
@@ -76,7 +76,7 @@ func resourceScalewaySecurityGroupRuleCreate(d *schema.ResourceData, m interface
 	mu.Lock()
 	defer mu.Unlock()
 
-	req := api.ScalewayNewSecurityGroupRule{
+	req := api.NewSecurityGroupRule{
 		Action:       d.Get("action").(string),
 		Direction:    d.Get("direction").(string),
 		IPRange:      d.Get("ip_range").(string),
@@ -84,7 +84,7 @@ func resourceScalewaySecurityGroupRuleCreate(d *schema.ResourceData, m interface
 		DestPortFrom: d.Get("port").(int),
 	}
 
-	err := scaleway.PostSecurityGroupRule(d.Get("security_group").(string), req)
+	rule, err := scaleway.PostSecurityGroupRule(d.Get("security_group").(string), req)
 	if err != nil {
 		if serr, ok := err.(api.ScalewayAPIError); ok {
 			log.Printf("[DEBUG] Error creating Security Group Rule: %q\n", serr.APIMessage)
@@ -93,25 +93,7 @@ func resourceScalewaySecurityGroupRuleCreate(d *schema.ResourceData, m interface
 		return err
 	}
 
-	resp, err := scaleway.GetSecurityGroupRules(d.Get("security_group").(string))
-	if err != nil {
-		return err
-	}
-
-	matches := func(rule api.ScalewaySecurityGroupRule) bool {
-		return rule.Action == req.Action &&
-			rule.Direction == req.Direction &&
-			rule.IPRange == req.IPRange &&
-			rule.Protocol == req.Protocol &&
-			rule.DestPortFrom == req.DestPortFrom
-	}
-
-	for _, rule := range resp.Rules {
-		if matches(rule) {
-			d.SetId(rule.ID)
-			break
-		}
-	}
+	d.SetId(rule.ID)
 
 	if d.Id() == "" {
 		return fmt.Errorf("Failed to find created security group rule")
@@ -152,7 +134,7 @@ func resourceScalewaySecurityGroupRuleUpdate(d *schema.ResourceData, m interface
 	mu.Lock()
 	defer mu.Unlock()
 
-	var req = api.ScalewayNewSecurityGroupRule{
+	var req = api.NewSecurityGroupRule{
 		Action:       d.Get("action").(string),
 		Direction:    d.Get("direction").(string),
 		IPRange:      d.Get("ip_range").(string),

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -552,10 +552,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "ROp7ZtwHdxYKpmwycOxbOOXNnzo=",
+			"checksumSHA1": "3QoIoQcuvO0CDnsgsLYa78XYT84=",
 			"path": "github.com/nicolai86/scaleway-sdk/api",
-			"revision": "33df10cad9fff60467a3dcb992d5340c2b9a8046",
-			"revisionTime": "2017-09-17T18:57:50Z"
+			"revision": "93cc5757856b2ff303e6bd21c998e0525f9708a1",
+			"revisionTime": "2017-12-02T17:25:18Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",


### PR DESCRIPTION
The Scaleway API returns the created Security Group, but the SDK did not surface that information.

I've fixed this in my fork of the SDK and improved the terraform provider to handle this situation better.

closes #25 