### PR TITLE
detect hung servers by improving startup/ shutdown detection

### DIFF
--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -208,7 +208,7 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 
-		err = waitForServerState(scaleway, id, "running")
+		err = waitForServerStartup(scaleway, id)
 
 		if v, ok := d.GetOk("public_ip"); ok {
 			if err := attachIP(scaleway, d.Id(), v.(string)); err != nil {

--- a/scaleway/resource_volume_attachment.go
+++ b/scaleway/resource_volume_attachment.go
@@ -66,7 +66,8 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 			return err
 		}
 	}
-	if err := waitForServerState(scaleway, server.Identifier, "stopped"); err != nil {
+
+	if err := waitForServerShutdown(scaleway, server.Identifier); err != nil {
 		return err
 	}
 
@@ -117,7 +118,7 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 		if err := scaleway.PostServerAction(serverID, "poweron"); err != nil {
 			return err
 		}
-		if err := waitForServerState(scaleway, serverID, "running"); err != nil {
+		if err := waitForServerStartup(scaleway, serverID); err != nil {
 			return err
 		}
 	}
@@ -190,7 +191,7 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 			return err
 		}
 	}
-	if err := waitForServerState(scaleway, server.Identifier, "stopped"); err != nil {
+	if err := waitForServerShutdown(scaleway, server.Identifier); err != nil {
 		return err
 	}
 
@@ -241,7 +242,7 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 		if err := scaleway.PostServerAction(serverID, "poweron"); err != nil {
 			return err
 		}
-		if err := waitForServerState(scaleway, serverID, "running"); err != nil {
+		if err := waitForServerStartup(scaleway, serverID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Explicitly declare valid pending states for startup/ shutdown. 
This will allow the proper detection of hung servers as `stopped` is no valid pending state for `startup`

closes #31 