### PR TITLE
Allow security group rule positions to be managed

### DIFF
--- a/scaleway/resource_security_group_rule_test.go
+++ b/scaleway/resource_security_group_rule_test.go
@@ -59,6 +59,26 @@ func TestAccScalewaySecurityGroupRule_Count(t *testing.T) {
 	})
 }
 
+func TestAccScalewaySecurityGroupRule_Position(t *testing.T) {
+	var group api.SecurityGroups
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewaySecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewaySecurityGroupRulePositionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewaySecurityGroupsExists("scaleway_security_group.base", &group),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.https", "position", "2"),
+					resource.TestCheckResourceAttr("scaleway_security_group_rule.http", "position", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckScalewaySecurityGroupsExists(n string, group *api.SecurityGroups) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -220,5 +240,34 @@ resource "scaleway_security_group_rule" "rule" {
     direction = "inbound"
     ip_range  = "${element(var.trusted_ips, count.index)}"
     protocol  = "TCP"
-    port      = "22"
+	port      = "22"
+	position  = ${count.index}
+}`
+
+var testAccCheckScalewaySecurityGroupRulePositionConfig = `
+resource "scaleway_security_group" "base" {
+    name        = "sg"
+    description = "sg rules w/ position"
+}
+
+resource "scaleway_security_group_rule" "https" {
+    security_group = "${scaleway_security_group.base.id}"
+
+    action    = "accept"
+    direction = "inbound"
+    ip_range  = "8.8.8.8"
+    protocol  = "TCP"
+	port      = "443"
+	position  = 2
+}
+
+resource "scaleway_security_group_rule" "http" {
+    security_group = "${scaleway_security_group.base.id}"
+
+    action    = "accept"
+    direction = "inbound"
+    ip_range  = "8.8.8.8"
+    protocol  = "TCP"
+	port      = "80"
+	position  = 1
 }`

--- a/vendor/github.com/nicolai86/scaleway-sdk/security_group_rule.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/security_group_rule.go
@@ -39,6 +39,16 @@ type NewSecurityGroupRule struct {
 	DestPortFrom int    `json:"dest_port_from,omitempty"`
 }
 
+// UpdateSecurityGroupRule definition POST/PUT request /_group/{groupID}
+type UpdateSecurityGroupRule struct {
+	Action       string `json:"action"`
+	Direction    string `json:"direction"`
+	IPRange      string `json:"ip_range"`
+	Protocol     string `json:"protocol"`
+	Position     int    `json:"position"`
+	DestPortFrom int    `json:"dest_port_from,omitempty"`
+}
+
 // GetSecurityGroupRules returns a GroupRules
 func (s *API) GetSecurityGroupRules(groupID string) (*GetSecurityGroupRules, error) {
 	resp, err := s.GetResponsePaginate(s.computeAPI, fmt.Sprintf("security_groups/%s/rules", groupID), url.Values{})
@@ -101,7 +111,7 @@ func (s *API) PostSecurityGroupRule(GroupID string, rules NewSecurityGroupRule) 
 }
 
 // PutGroupRule updates a SecurityGroupRule
-func (s *API) PutSecurityGroupRule(rules NewSecurityGroupRule, GroupID, RuleID string) error {
+func (s *API) PutSecurityGroupRule(rules UpdateSecurityGroupRule, GroupID, RuleID string) error {
 	resp, err := s.PutResponse(s.computeAPI, fmt.Sprintf("security_groups/%s/rules/%s", GroupID, RuleID), rules)
 	if err != nil {
 		return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -558,10 +558,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "2JjgXBpgbkd8EgPFDECfpaLHu/Y=",
+			"checksumSHA1": "HugjtYGth3ldw8Lqo444yxEa3iQ=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "34a027fdee9e6debfb6d0182f75f43ba24107edf",
-			"revisionTime": "2018-01-15T01:31:29Z"
+			"revision": "cb3d4cbe6f14943e8caae15d57a9f889ed4b0b35",
+			"revisionTime": "2018-02-26T00:05:58Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
 * `ip_range` - (Required) ip_range of rule
 * `protocol` - (Required) protocol of rule (`ICMP`, `TCP`, `UDP`)
 * `port` - (Optional) port of the rule
+* `position` - (Optional) position of the rule within the security group
 
 Fields `action`, `direction`, `ip_range`, `protocol`, `port` are editable.
 
@@ -48,3 +49,4 @@ Fields `action`, `direction`, `ip_range`, `protocol`, `port` are editable.
 The following attributes are exported:
 
 * `id` - id of the new resource
+* `position` - position of the resource within the security group


### PR DESCRIPTION
Scaleway allows the position to be set in update calls - create calls
ignore the attribute.
To support ordering of security group rules the terraform resource will
first issue a create, and afterwards issue an update call.

closes #24