### PR TITLE
Allow security group default rules to be disabled

### DIFF
--- a/scaleway/resource_security_group.go
+++ b/scaleway/resource_security_group.go
@@ -29,6 +29,13 @@ func resourceScalewaySecurityGroup() *schema.Resource {
 				Required:    true,
 				Description: "The description of the security group",
 			},
+			"enable_default_security": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				ForceNew:    true,
+				Description: "Add default security group rules",
+			},
 		},
 	}
 }
@@ -40,9 +47,10 @@ func resourceScalewaySecurityGroupCreate(d *schema.ResourceData, m interface{}) 
 	defer mu.Unlock()
 
 	req := api.NewSecurityGroup{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		Organization: scaleway.Organization,
+		Name:                  d.Get("name").(string),
+		Description:           d.Get("description").(string),
+		Organization:          scaleway.Organization,
+		EnableDefaultSecurity: d.Get("enable_default_security").(bool),
 	}
 
 	err := scaleway.PostSecurityGroup(req)
@@ -92,6 +100,7 @@ func resourceScalewaySecurityGroupRead(d *schema.ResourceData, m interface{}) er
 
 	d.Set("name", resp.SecurityGroups.Name)
 	d.Set("description", resp.SecurityGroups.Description)
+	d.Set("enable_default_security", resp.SecurityGroups.EnableDefaultSecurity)
 
 	return nil
 }

--- a/scaleway/resource_security_group_rule.go
+++ b/scaleway/resource_security_group_rule.go
@@ -134,7 +134,7 @@ func resourceScalewaySecurityGroupRuleUpdate(d *schema.ResourceData, m interface
 	mu.Lock()
 	defer mu.Unlock()
 
-	var req = api.NewSecurityGroupRule{
+	var req = api.UpdateSecurityGroupRule{
 		Action:       d.Get("action").(string),
 		Direction:    d.Get("direction").(string),
 		IPRange:      d.Get("ip_range").(string),

--- a/vendor/github.com/nicolai86/scaleway-sdk/security_group.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/security_group.go
@@ -39,9 +39,10 @@ type SecurityGroup struct {
 
 // NewSecurityGroup definition POST request /security_groups
 type NewSecurityGroup struct {
-	Organization string `json:"organization"`
-	Name         string `json:"name"`
-	Description  string `json:"description"`
+	Organization          string `json:"organization"`
+	Name                  string `json:"name"`
+	Description           string `json:"description"`
+	EnableDefaultSecurity bool   `json:"enable_default_security"`
 }
 
 // UpdateSecurityGroup definition PUT request /security_groups

--- a/vendor/github.com/nicolai86/scaleway-sdk/security_group_rule.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/security_group_rule.go
@@ -39,6 +39,16 @@ type NewSecurityGroupRule struct {
 	DestPortFrom int    `json:"dest_port_from,omitempty"`
 }
 
+// UpdateSecurityGroupRule definition POST/PUT request /_group/{groupID}
+type UpdateSecurityGroupRule struct {
+	Action       string `json:"action"`
+	Direction    string `json:"direction"`
+	IPRange      string `json:"ip_range"`
+	Protocol     string `json:"protocol"`
+	Position     int    `json:"position"`
+	DestPortFrom int    `json:"dest_port_from,omitempty"`
+}
+
 // GetSecurityGroupRules returns a GroupRules
 func (s *API) GetSecurityGroupRules(groupID string) (*GetSecurityGroupRules, error) {
 	resp, err := s.GetResponsePaginate(s.computeAPI, fmt.Sprintf("security_groups/%s/rules", groupID), url.Values{})
@@ -101,7 +111,7 @@ func (s *API) PostSecurityGroupRule(GroupID string, rules NewSecurityGroupRule) 
 }
 
 // PutGroupRule updates a SecurityGroupRule
-func (s *API) PutSecurityGroupRule(rules NewSecurityGroupRule, GroupID, RuleID string) error {
+func (s *API) PutSecurityGroupRule(rules UpdateSecurityGroupRule, GroupID, RuleID string) error {
 	resp, err := s.PutResponse(s.computeAPI, fmt.Sprintf("security_groups/%s/rules/%s", GroupID, RuleID), rules)
 	if err != nil {
 		return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -558,10 +558,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "2JjgXBpgbkd8EgPFDECfpaLHu/Y=",
+			"checksumSHA1": "7ILxxEwddNgVCzVHzLCnPJfEBWg=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "34a027fdee9e6debfb6d0182f75f43ba24107edf",
-			"revisionTime": "2018-01-15T01:31:29Z"
+			"revision": "6ef8f978a49b7615d7bf9c4f0d2e651f42a41852",
+			"revisionTime": "2018-02-27T05:29:25Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -15,8 +15,9 @@ For additional details please refer to [API documentation](https://developer.sca
 
 ```hcl
 resource "scaleway_security_group" "test" {
-  name        = "test"
-  description = "test"
+  name                    = "test"
+  description             = "test"
+  enable_default_security = true
 }
 ```
 
@@ -26,6 +27,7 @@ The following arguments are supported:
 
 * `name` - (Required) name of security group
 * `description` - (Required) description of security group
+* `enable_default_security` - (Optional) default: true. Add default security group rules
 
 Field `name`, `description` are editable.
 


### PR DESCRIPTION
As specified in #33, it is possible to control the security group default rule creation.

This CR exposes a new attribute, `enable_default_security` which can be set to `false` to disable the default security group rules applied by scaleway. Default: `true`.

closes #33 