### PR TITLE
guard against missing ipv6 information

### DIFF
--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -248,7 +248,7 @@ func resourceScalewayServerRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("private_ip", server.PrivateIP)
 	d.Set("public_ip", server.PublicAddress.IP)
 
-	if server.EnableIPV6 {
+	if server.EnableIPV6 && server.IPV6 != nil {
 		d.Set("public_ipv6", server.IPV6.Address)
 	}
 


### PR DESCRIPTION
See #42. The follow terraform code produces a crash:

```
provider "scaleway" {}

data "scaleway_image" "centos_7_3" {
  architecture = "x86_64"
  name         = "CentOS 7.3"
}

resource "scaleway_server" "test" {
  name        = "test"
  image       = "${data.scaleway_image.centos_7_3.id}"
  type        = "VC1M"
  tags        = ["test"]
  enable_ipv6 = true
  state       = "stopped"

  volume {
    size_in_gb = 50
    type       = "l_ssd"
  }
}
```

breaks if the server is in a stopped state, in which case the IPv6 information is not available.

fixes #42