### PR TITLE
add support for managing ip reverse attribute

### DIFF
--- a/scaleway/resource_ip_test.go
+++ b/scaleway/resource_ip_test.go
@@ -69,12 +69,22 @@ func TestAccScalewayIP_Basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
+				Config: testAccCheckScalewayIPConfig_Reverse,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIPExists("scaleway_ip.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_ip.base", "reverse", "www.google.de"),
+				),
+			},
+			resource.TestStep{
 				Config: testAccCheckScalewayIPAttachConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayIPExists("scaleway_ip.base"),
 					testAccCheckScalewayIPAttachment("scaleway_ip.base", func(serverID string) bool {
 						return serverID != ""
 					}, "attachment failed"),
+					resource.TestCheckResourceAttr(
+						"scaleway_ip.base", "reverse", ""),
 				),
 			},
 			resource.TestStep{
@@ -172,9 +182,14 @@ func testAccCheckScalewayIPAttachment(n string, check func(string) bool, msg str
 	}
 }
 
-var testAccCheckScalewayIPConfig = `
+var testAccCheckScalewayIPConfig_Reverse = `
 resource "scaleway_ip" "base" {
+  reverse = "www.google.de"
 }
+`
+
+var testAccCheckScalewayIPConfig = `
+resource "scaleway_ip" "base" {}
 `
 
 var testAccCheckScalewayIPConfig_Count = `

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -558,10 +558,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "HHM/BHbGWERr3u0mwCsj+587zBY=",
+			"checksumSHA1": "TFoFErx/R+wtqKsYAY+mzbLtbCA=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "1a18b6a1c6a3434c88b908254958f1281cf3ac2c",
-			"revisionTime": "2018-03-15T02:26:51Z"
+			"revision": "1e466487c486466a8ba2cfb48fac56788a8095ea",
+			"revisionTime": "2018-03-15T04:05:42Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/ip.html.markdown
+++ b/website/docs/r/ip.html.markdown
@@ -22,15 +22,16 @@ resource "scaleway_ip" "test_ip" {}
 The following arguments are supported:
 
 * `server` - (Optional) ID of server to associate IP with
-
-Field `server` is editable.
+* `reverse` - (Optional) Reverse DNS of the IP
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - id of the new resource
+* `id` - ID of the new resource
 * `ip` - IP of the new resource
+* `server` - ID of the associated server resource
+* `reverse` - reverse DNS setting of the IP resource
 
 ## Import
 


### PR DESCRIPTION
This PR adds support to manage `scaleway_ip`s `reverse` attribute.
The change includes an update to the `github.com/nicolai86/scaleway-sdk` dependency, as well as document and test updates.

The changed resource looks like this:

```
resource "scaleway_ip" "test" {
  reverse = "www.google.com"
}
```

Once merged, closes #34 