### PR TITLE
guard against crashes due to missing responses

### DIFF
--- a/scaleway/config.go
+++ b/scaleway/config.go
@@ -63,6 +63,9 @@ func (c *Config) Client() (*Client, error) {
 			cl.Logger = log.New(os.Stderr, "", 0)
 			cl.RetryWaitMin = time.Minute
 			cl.CheckRetry = func(resp *http.Response, err error) (bool, error) {
+				if resp == nil {
+					return true, err
+				}
 				if resp.StatusCode == http.StatusTooManyRequests {
 					return true, err
 				}


### PR DESCRIPTION
when using the provider over a slow uplink like an airplane or train
sometimes no response is provided. these cases should be handled as a
retry.

instead, the provider crashes at the moment