### PR TITLE
add scaleway_token resource

### DIFF
--- a/scaleway/import_token_test.go
+++ b/scaleway/import_token_test.go
@@ -1,0 +1,28 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewayToken_importBasic(t *testing.T) {
+	resourceName := "scaleway_token.base"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayTokenDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayTokenConfig_Update,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -45,6 +45,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"scaleway_server":              resourceScalewayServer(),
+			"scaleway_token":               resourceScalewayToken(),
 			"scaleway_ssh_key":             resourceScalewaySSHKey(),
 			"scaleway_ip":                  resourceScalewayIP(),
 			"scaleway_security_group":      resourceScalewaySecurityGroup(),

--- a/scaleway/resource_token.go
+++ b/scaleway/resource_token.go
@@ -1,0 +1,145 @@
+package scaleway
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/nicolai86/scaleway-sdk"
+)
+
+func resourceScalewayToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceScalewayTokenCreate,
+		Read:   resourceScalewayTokenRead,
+		Update: resourceScalewayTokenUpdate,
+		Delete: resourceScalewayTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"email": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The account email. Defaults to registered user.",
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The userid of the associated user.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The token description.",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "User password, in case a login is require",
+			},
+			"expires": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Defines if the token is set to expire",
+			},
+			"expiration_date": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The tokens expiration date",
+			},
+		},
+	}
+}
+
+func resourceScalewayTokenCreate(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	mu.Lock()
+	email := ""
+	if mail, ok := d.GetOk("email"); ok {
+		email = mail.(string)
+	} else {
+		user, err := scaleway.GetUser()
+		if err != nil {
+			return err
+		}
+		email = user.Email
+	}
+
+	token, err := scaleway.CreateToken(&api.CreateTokenRequest{
+		Email:    email,
+		Password: d.Get("password").(string),
+		Expires:  d.Get("expires").(bool),
+	})
+	mu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(token.ID)
+	return resourceScalewayTokenUpdate(d, m)
+}
+
+func resourceScalewayTokenRead(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	token, err := scaleway.GetToken(d.Id())
+	if err != nil {
+		if serr, ok := err.(api.APIError); ok {
+			if serr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+	d.Set("description", token.Description)
+	d.Set("expiration_date", token.Expires)
+	d.Set("expires", token.Expires != "")
+	d.Set("user_id", token.UserID)
+	user, err := scaleway.GetUser()
+	if err != nil {
+		return err
+	}
+	if user.ID == token.UserID {
+		d.Set("email", user.Email)
+	}
+
+	return nil
+}
+
+func resourceScalewayTokenUpdate(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if d.HasChange("description") || d.HasChange("expires") {
+		_, err := scaleway.UpdateToken(&api.UpdateTokenRequest{
+			ID:          d.Id(),
+			Expires:     d.Get("expires").(bool),
+			Description: d.Get("description").(string),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceScalewayTokenRead(d, m)
+}
+
+func resourceScalewayTokenDelete(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	err := scaleway.DeleteToken(d.Id())
+	if err != nil {
+		return err
+	}
+	d.SetId("")
+	return nil
+}

--- a/scaleway/resource_token_test.go
+++ b/scaleway/resource_token_test.go
@@ -1,0 +1,149 @@
+package scaleway
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("scaleway_token", &resource.Sweeper{
+		Name: "scaleway_token",
+		F:    testSweepToken,
+	})
+}
+
+func testSweepToken(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	scaleway := client.(*Client).scaleway
+	log.Printf("[DEBUG] Destroying the tokens in (%s)", region)
+
+	tokens, err := scaleway.GetTokens()
+	if err != nil {
+		return fmt.Errorf("Error describing tokens in Sweeper: %s", err)
+	}
+
+	for _, token := range tokens {
+		if err := scaleway.DeleteToken(token.ID); err != nil {
+			return fmt.Errorf("Error deleting token in Sweeper: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccScalewayToken_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayTokenDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayTokenConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayTokenExists("scaleway_token.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_token.base", "description", "just a test"),
+					resource.TestCheckResourceAttr(
+						"scaleway_token.base", "expires", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckScalewayTokenConfig_Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayTokenExists("scaleway_token.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_token.base", "description", "just a test 222"),
+					resource.TestCheckResourceAttrSet("scaleway_token.base", "expiration_date"),
+					resource.TestCheckResourceAttr(
+						"scaleway_token.base", "expires", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccScalewayToken_Expiry(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayTokenDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayTokenConfig_Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayTokenExists("scaleway_token.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_token.base", "description", "just a test 222"),
+					resource.TestCheckResourceAttrSet("scaleway_token.base", "expiration_date"),
+					resource.TestCheckResourceAttr(
+						"scaleway_token.base", "expires", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayTokenDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client).scaleway
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "scaleway" {
+			continue
+		}
+
+		_, err := client.GetToken(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Token still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckScalewayTokenExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Token ID is set")
+		}
+
+		client := testAccProvider.Meta().(*Client).scaleway
+		token, err := client.GetToken(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if token.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		return nil
+	}
+}
+
+var testAccCheckScalewayTokenConfig = `
+resource "scaleway_token" "base" {
+	expires = false
+	description = "just a test"
+}`
+
+var testAccCheckScalewayTokenConfig_Update = `
+resource "scaleway_token" "base" {
+	expires = true
+	description = "just a test 222"
+}`

--- a/vendor/github.com/nicolai86/scaleway-sdk/tokens.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/tokens.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Token represents a  Token
+type Token struct {
+	UserID             string `json:"user_id"`
+	Description        string `json:"description,omitempty"`
+	Roles              Role   `json:"roles"`
+	Expires            string `json:"expires"`
+	InheritsUsersPerms bool   `json:"inherits_user_perms"`
+	ID                 string `json:"id"`
+}
+
+// Role represents a  Token UserId Role
+type Role struct {
+	Organization Organization `json:"organization,omitempty"`
+	Role         string       `json:"role,omitempty"`
+}
+
+type getTokenResponse struct {
+	Token Token `json:"token"`
+}
+
+type getTokensResponse struct {
+	Tokens []Token `json:"tokens"`
+}
+
+func (s *API) GetTokens() ([]Token, error) {
+	query := url.Values{}
+	// TODO per_page=20&page=2
+	resp, err := s.GetResponsePaginate(s.computeAPI, "tokens", query)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
+	if err != nil {
+		return nil, err
+	}
+	var token getTokensResponse
+
+	if err = json.Unmarshal(body, &token); err != nil {
+		return nil, err
+	}
+	return token.Tokens, nil
+}
+
+type CreateTokenRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password,omitempty"`
+	Expires  bool   `json:"expires"`
+}
+
+func (s *API) CreateToken(req *CreateTokenRequest) (*Token, error) {
+	resp, err := s.PostResponse(AccountAPI, "tokens", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusCreated}, resp)
+	if err != nil {
+		return nil, err
+	}
+	var data getTokenResponse
+
+	if err = json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+	return &data.Token, nil
+}
+
+type UpdateTokenRequest struct {
+	Description string `json:"description,omitempty"`
+	Expires     bool   `json:"expires"`
+	ID          string `json:"-"`
+}
+
+func (s *API) UpdateToken(req *UpdateTokenRequest) (*Token, error) {
+	resp, err := s.PatchResponse(AccountAPI, fmt.Sprintf("tokens/%s", req.ID), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
+	if err != nil {
+		return nil, err
+	}
+	var data getTokenResponse
+
+	if err = json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+	return &data.Token, nil
+}
+
+func (s *API) GetToken(id string) (*Token, error) {
+	query := url.Values{}
+	resp, err := s.GetResponsePaginate(AccountAPI, fmt.Sprintf("tokens/%s", id), query)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
+	if err != nil {
+		return nil, err
+	}
+	var data getTokenResponse
+
+	if err = json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+	return &data.Token, nil
+}
+
+func (s *API) DeleteToken(id string) error {
+	resp, err := s.DeleteResponse(AccountAPI, fmt.Sprintf("tokens/%s", id))
+	if err != nil {
+		return err
+	}
+
+	if _, err = s.handleHTTPError([]int{http.StatusNoContent}, resp); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/nicolai86/scaleway-sdk/user.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/user.go
@@ -7,32 +7,6 @@ import (
 	"net/url"
 )
 
-// TokenDefinition represents a  Token
-type TokenDefinition struct {
-	UserID             string `json:"user_id"`
-	Description        string `json:"description,omitempty"`
-	Roles              Role   `json:"roles"`
-	Expires            string `json:"expires"`
-	InheritsUsersPerms bool   `json:"inherits_user_perms"`
-	ID                 string `json:"id"`
-}
-
-// TokensDefinition represents a  Tokens
-type TokensDefinition struct {
-	Token TokenDefinition `json:"token"`
-}
-
-// GetTokens represents a list of  Tokens
-type GetTokens struct {
-	Tokens []TokenDefinition `json:"tokens"`
-}
-
-// Role represents a  Token UserId Role
-type Role struct {
-	Organization Organization `json:"organization,omitempty"`
-	Role         string       `json:"role,omitempty"`
-}
-
 // User represents a  User
 type User struct {
 	Email         string          `json:"email"`
@@ -94,7 +68,7 @@ func (s *API) GetUserID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var token TokensDefinition
+	var token getTokenResponse
 
 	if err = json.Unmarshal(body, &token); err != nil {
 		return "", err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -558,10 +558,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "/4UnwsRIHPFUsCEqsAOZspBcv9w=",
+			"checksumSHA1": "qPUxUkRxA0nnbZ9Pb7yUor1P7Fg=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "18390255e076ea40dab45aa9aa3975ab6fd9de1e",
-			"revisionTime": "2018-03-31T01:22:51Z"
+			"revision": "d749f7b83389f1afe19b81a610fad5ebb7a12744",
+			"revisionTime": "2018-04-01T05:36:48Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/token.html.markdown
+++ b/website/docs/r/token.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: token"
+sidebar_current: "docs-scaleway-resource-token"
+description: |-
+  Manages Scaleway Tokens.
+---
+
+# scaleway\_token
+
+Provides Tokens for scaleway API access. For additional details please refer to [API documentation](https://developer.scaleway.com/#tokens-tokens-post).
+
+## Example Usage
+
+```hcl
+resource "scaleway_token" "karls_token" {
+    expires = false
+    description = "karls scaleway access: karl@company.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `expires` - (Optional) Define if the token should automatically expire or not
+* `email` - (Optional) Scaleway account email. Defaults to registered account
+* `password` - (Optional) Scaleway account password. Required for cross-account token management
+* `description` - (Optional) Token description
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Token ID - can be used to access scaleway API
+* `expiration_date` - Expiration date of token, if expiration is requested
+
+## Import
+
+Instances can be imported using the `id`, e.g.
+
+```
+$ terraform import scaleway_token.karls_token 5faef9cd-ea9b-4a63-9171-9e26bec03dbc
+```

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -40,6 +40,9 @@
             <li<%= sidebar_current("docs-scaleway-resource-volume") %>>
               <a href="/docs/providers/scaleway/r/volume.html">scaleway_volume</a>
             </li>
+            <li<%= sidebar_current("docs-scaleway-resource-token") %>>
+              <a href="/docs/providers/scaleway/r/token.html">scaleway_token</a>
+            </li>
             <li<%= sidebar_current("docs-scaleway-resource-volume_attachment") %>>
               <a href="/docs/providers/scaleway/r/volume_attachment.html">scaleway_volume_attachment</a>
             </li>


### PR DESCRIPTION
this PR adds a new scaleway resource: `scaleway_token`.

`scaleway_token` can be used to generate additional scaleway access tokens; usage looks like this:

```
resource "scaleway_token" "karls_token" {
    expires = false
    description = "karls scaleway access: karl@company.com"
}
```

See the attached documentation for details. Tests are green:

```
# make testacc TESTARGS="-run='TestAccScalewayToken_Basic'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccScalewayToken_Basic' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
=== RUN   TestAccScalewayToken_Basic
--- PASS: TestAccScalewayToken_Basic (19.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	19.215s
```