### PR TITLE
resource/server: support boot_type

### DIFF
--- a/scaleway/resource_server_test.go
+++ b/scaleway/resource_server_test.go
@@ -63,6 +63,8 @@ func TestAccScalewayServer_Basic(t *testing.T) {
 						"scaleway_server.base", "name", "test"),
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "tags.0", "terraform-test"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "boot_type", "bootscript"),
 				),
 			},
 			resource.TestStep{
@@ -75,6 +77,23 @@ func TestAccScalewayServer_Basic(t *testing.T) {
 				Config: testAccCheckScalewayServerConfig_IPDetachment,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayServerIPDetachmentAttributes("scaleway_server.base"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccScalewayServer_BootType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayServerConfig_LocalBoot,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "boot_type", "local"),
 				),
 			},
 		},
@@ -301,6 +320,7 @@ func testAccCheckScalewayServerExists(n string) resource.TestCheckFunc {
 }
 
 var armImageIdentifier = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
+var x86_64ImageIdentifier = "e20532c4-1fa0-4c97-992f-436b8d372c07"
 
 var testAccCheckScalewayServerConfig = fmt.Sprintf(`
 resource "scaleway_server" "base" {
@@ -310,6 +330,16 @@ resource "scaleway_server" "base" {
   type = "C1"
   tags = [ "terraform-test" ]
 }`, armImageIdentifier)
+
+var testAccCheckScalewayServerConfig_LocalBoot = fmt.Sprintf(`
+resource "scaleway_server" "base" {
+  name = "test"
+  # ubuntu 14.04
+  image = "%s"
+  type = "VC1S"
+  tags = [ "terraform-test" ]
+  boot_type = "local"
+}`, x86_64ImageIdentifier)
 
 var testAccCheckScalewayServerConfig_IPAttachment = fmt.Sprintf(`
 resource "scaleway_ip" "base" {}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,191 @@
+package validation
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// NoZeroValues is a SchemaValidateFunc which tests if the provided value is
+// not a zero value. It's useful in situations where you want to catch
+// explicit zero values on things like required fields during validation.
+func NoZeroValues(i interface{}, k string) (s []string, es []error) {
+	if reflect.ValueOf(i).Interface() == reflect.Zero(reflect.TypeOf(i)).Interface() {
+		switch reflect.TypeOf(i).Kind() {
+		case reflect.String:
+			es = append(es, fmt.Errorf("%s must not be empty", k))
+		case reflect.Int, reflect.Float64:
+			es = append(es, fmt.Errorf("%s must not be zero", k))
+		default:
+			// this validator should only ever be applied to TypeString, TypeInt and TypeFloat
+			panic(fmt.Errorf("can't use NoZeroValues with %T attribute %s", i, k))
+		}
+	}
+	return
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+// ValidateJsonString is a SchemaValidateFunc which tests to make sure the
+// supplied string is valid JSON.
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}
+
+// ValidateListUniqueStrings is a ValidateFunc that ensures a list has no
+// duplicate items in it. It's useful for when a list is needed over a set
+// because order matters, yet the items still need to be unique.
+func ValidateListUniqueStrings(v interface{}, k string) (ws []string, errors []error) {
+	for n1, v1 := range v.([]interface{}) {
+		for n2, v2 := range v.([]interface{}) {
+			if v1.(string) == v2.(string) && n1 != n2 {
+				errors = append(errors, fmt.Errorf("%q: duplicate entry - %s", k, v1.(string)))
+			}
+		}
+	}
+	return
+}
+
+// ValidateRegexp returns a SchemaValidateFunc which tests to make sure the
+// supplied string is a valid regular expression.
+func ValidateRegexp(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := regexp.Compile(v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+	return
+}

--- a/vendor/github.com/nicolai86/scaleway-sdk/server.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/server.go
@@ -48,6 +48,9 @@ type Server struct {
 	// Bootscript is the unique identifier of the selected bootscript
 	Bootscript *Bootscript `json:"bootscript,omitempty"`
 
+	// BootType defines the type of boot. Can be local or bootscript
+	BootType string `json:"boot_type,omitempty"`
+
 	// Hostname represents the ServerName in a format compatible with unix's hostname
 	Hostname string `json:"hostname,omitempty"`
 
@@ -133,6 +136,9 @@ type ServerDefinition struct {
 
 	// CommercialType is the commercial type of the server (i.e: C1, C2[SML], VC1S)
 	CommercialType string `json:"commercial_type"`
+
+	// BootType defines the type of boot. Can be local or bootscript
+	BootType string `json:"boot_type,omitempty"`
 
 	PublicIP string `json:"public_ip,omitempty"`
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -486,6 +486,18 @@
 			"versionExact": "v0.10.0"
 		},
 		{
+			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
+			"path": "github.com/hashicorp/terraform/helper/structure",
+			"revision": "90e986348ad914b0fffb67feddd0924c0e741c4f",
+			"revisionTime": "2017-12-01T22:04:31Z"
+		},
+		{
+			"checksumSHA1": "jdwWpJZbTSU87GUlwLTuf6FwpmE=",
+			"path": "github.com/hashicorp/terraform/helper/validation",
+			"revision": "90e986348ad914b0fffb67feddd0924c0e741c4f",
+			"revisionTime": "2017-12-01T22:04:31Z"
+		},
+		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
 			"revision": "5bcc1bae5925f44208a83279b6d4d250da01597b",
@@ -558,10 +570,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "qPUxUkRxA0nnbZ9Pb7yUor1P7Fg=",
+			"checksumSHA1": "n8j/CVEarUKArSLFjbZ4vMcxKf4=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "d749f7b83389f1afe19b81a610fad5ebb7a12744",
-			"revisionTime": "2018-04-01T05:36:48Z"
+			"revision": "514d84f85641e74c600b56fb9ec5083cd4803a73",
+			"revisionTime": "2018-04-25T16:23:49Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `image` - (Required) base image of server
 * `type` - (Required) type of server
 * `bootscript` - (Optional) server bootscript
+* `boot_type` - (Optional) the boot mechanism for this server. Possible values include `local` and `bootscript`
 * `tags` - (Optional) list of tags for server
 * `enable_ipv6` - (Optional) enable ipv6
 * `dynamic_ip_required` - (Optional) make server publicly available


### PR DESCRIPTION
this PR adds support for the [newly introduced boot_type](https://blog.online.net/2018/04/19/scaleway-feature-improvements-custom-kernel-security-group-live-reload-imagehub-packer/) attribute for scaleway server resources:

```
resource "scaleway_server" "base" {
  name = "test"
  image = "e20532c4-1fa0-4c97-992f-436b8d372c07"
  type = "VC1S"
  tags = [ "terraform-test" ]
  boot_type = "local"
}
```

valid values are `local` and `bootscript` for x86_64, as well as `bootscript` for arm instance types.

Tests are green:

```
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (8.64s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (26.29s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (23.28s)
=== RUN   TestValidateBootType
=== RUN   TestValidateBootType/local
=== RUN   TestValidateBootType/bootscript
=== RUN   TestValidateBootType/remote
--- PASS: TestValidateBootType (0.00s)
    --- PASS: TestValidateBootType/local (0.00s)
    --- PASS: TestValidateBootType/bootscript (0.00s)
    --- PASS: TestValidateBootType/remote (0.00s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (12.73s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (14.63s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (151.10s)
=== RUN   TestAccScalewayToken_importBasic
--- PASS: TestAccScalewayToken_importBasic (22.30s)
=== RUN   TestAccScalewayUserData_importBasic
--- PASS: TestAccScalewayUserData_importBasic (18.98s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (8.19s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccScalewayIP_Count
--- PASS: TestAccScalewayIP_Count (25.56s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (61.75s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (32.84s)
=== RUN   TestAccScalewaySecurityGroupRule_Count
--- PASS: TestAccScalewaySecurityGroupRule_Count (23.28s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (11.70s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (174.10s)
=== RUN   TestAccScalewayServer_BootType
--- PASS: TestAccScalewayServer_BootType (69.84s)
=== RUN   TestAccScalewayServer_ExistingIP
--- PASS: TestAccScalewayServer_ExistingIP (137.15s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (160.96s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (227.32s)
=== RUN   TestGetSSHKeyFingerprint
--- PASS: TestGetSSHKeyFingerprint (0.00s)
=== RUN   TestAccScalewaySSHKey_Basic
--- PASS: TestAccScalewaySSHKey_Basic (32.16s)
=== RUN   TestAccScalewayToken_Basic
--- PASS: TestAccScalewayToken_Basic (34.44s)
=== RUN   TestAccScalewayToken_Expiry
--- PASS: TestAccScalewayToken_Expiry (19.44s)
=== RUN   TestAccScalewayUserData_Basic
--- PASS: TestAccScalewayUserData_Basic (25.95s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (160.50s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (9.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	1493.039s
```