### PR TITLE
switch server type API

### DIFF
--- a/scaleway/config.go
+++ b/scaleway/config.go
@@ -84,6 +84,9 @@ func (c *Config) Client() (*Client, error) {
 			commercialServerTypes = availability.CommercialTypes()
 			sort.StringSlice(commercialServerTypes).Sort()
 		}
+		if os.Getenv("DISABLE_SCALEWAY_SERVER_TYPE_VALIDATION") != "" {
+			commercialServerTypes = commercialServerTypes[:0]
+		}
 	}
 	return &Client{api}, nil
 }

--- a/vendor/github.com/nicolai86/scaleway-sdk/api.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/api.go
@@ -27,13 +27,11 @@ import (
 // https://cp-ams1..com/products/servers
 // Default values
 var (
-	AccountAPI          = "https://account.scaleway.com/"
-	MetadataAPI         = "http://169.254.42.42/"
-	MarketplaceAPI      = "https://api-marketplace.scaleway.com"
-	ComputeAPIPar1      = "https://cp-par1.scaleway.com/"
-	ComputeAPIAms1      = "https://cp-ams1.scaleway.com/"
-	AvailabilityAPIPar1 = "https://availability.scaleway.com/"
-	AvailabilityAPIAms1 = "https://availability-ams1.scaleway.com/"
+	AccountAPI     = "https://account.scaleway.com/"
+	MetadataAPI    = "http://169.254.42.42/"
+	MarketplaceAPI = "https://api-marketplace.scaleway.com"
+	ComputeAPIPar1 = "https://cp-par1.scaleway.com/"
+	ComputeAPIAms1 = "https://cp-ams1.scaleway.com/"
 
 	URLPublicDNS  = ".pub.cloud.scaleway.com"
 	URLPrivateDNS = ".priv.cloud.scaleway.com"
@@ -66,10 +64,9 @@ type API struct {
 	Token        string     // Token is the authentication token for the  organization
 	Client       HTTPClient // Client is used for all HTTP interactions
 
-	password        string // Password is the authentication password
-	userAgent       string
-	computeAPI      string
-	availabilityAPI string
+	password   string // Password is the authentication password
+	userAgent  string
+	computeAPI string
 
 	Region string
 }
@@ -123,19 +120,14 @@ func New(organization, token, region string, options ...func(*API)) (*API, error
 	switch region {
 	case "par1", "":
 		s.computeAPI = ComputeAPIPar1
-		s.availabilityAPI = AvailabilityAPIPar1
 	case "ams1":
 		s.computeAPI = ComputeAPIAms1
-		s.availabilityAPI = AvailabilityAPIAms1
 	default:
 		return nil, fmt.Errorf("%s isn't a valid region", region)
 	}
 	s.Region = region
 	if url := os.Getenv("SCW_COMPUTE_API"); url != "" {
 		s.computeAPI = url
-	}
-	if url := os.Getenv("SCW_AVAILABILITY_API"); url != "" {
-		s.availabilityAPI = url
 	}
 	return s, nil
 }

--- a/vendor/github.com/nicolai86/scaleway-sdk/availability.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/availability.go
@@ -10,17 +10,18 @@ type ServerAvailabilities map[string]interface{}
 
 func (a ServerAvailabilities) CommercialTypes() []string {
 	types := []string{}
-	for k, v := range a {
-		if _, ok := v.(bool); !ok {
-			continue
-		}
+	for k, _ := range a {
 		types = append(types, k)
 	}
 	return types
 }
 
+type availabilityResponse struct {
+	Servers ServerAvailabilities
+}
+
 func (s *API) GetServerAvailabilities() (ServerAvailabilities, error) {
-	resp, err := s.response("GET", fmt.Sprintf("%s/availability.json", s.availabilityAPI), nil)
+	resp, err := s.response("GET", fmt.Sprintf("%s/products/servers/availability", s.computeAPI), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -29,9 +30,9 @@ func (s *API) GetServerAvailabilities() (ServerAvailabilities, error) {
 	if err != nil {
 		return nil, err
 	}
-	content := ServerAvailabilities{}
+	content := availabilityResponse{}
 	if err := json.Unmarshal(bs, &content); err != nil {
 		return nil, err
 	}
-	return content, nil
+	return content.Servers, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -570,10 +570,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "n8j/CVEarUKArSLFjbZ4vMcxKf4=",
+			"checksumSHA1": "5PC3eHJZwTMQyGJltpcIJp/aCNw=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "514d84f85641e74c600b56fb9ec5083cd4803a73",
-			"revisionTime": "2018-04-25T16:23:49Z"
+			"revision": "4871b0a66c85ce1a78bb5d8a62714ed1a5669650",
+			"revisionTime": "2018-05-12T06:04:43Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",


### PR DESCRIPTION
fixes #62 by switching to a different Scaleway API to fetch server availability.

Also, it allows the validation to be disabled by setting `DISABLE_SCALEWAY_SERVER_TYPE_VALIDATION`