### PR TITLE
r/server: validate instance type availability

### DIFF
--- a/vendor/github.com/nicolai86/scaleway-sdk/availability.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/availability.go
@@ -6,7 +6,19 @@ import (
 	"io/ioutil"
 )
 
-type ServerAvailabilities map[string]interface{}
+type InstanceTypeAvailability string
+
+var (
+	InstanceTypeAvailable InstanceTypeAvailability = "available"
+	InstanceTypeScarce    InstanceTypeAvailability = "scarce"
+	InstanceTypeShortage  InstanceTypeAvailability = "shortage"
+)
+
+type ServerAvailability struct {
+	Availability InstanceTypeAvailability `json:"availability"`
+}
+
+type ServerAvailabilities map[string]ServerAvailability
 
 func (a ServerAvailabilities) CommercialTypes() []string {
 	types := []string{}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -570,10 +570,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "5PC3eHJZwTMQyGJltpcIJp/aCNw=",
+			"checksumSHA1": "ucJEyEBIAPbSsctcjxHTqN/1aoo=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "4871b0a66c85ce1a78bb5d8a62714ed1a5669650",
-			"revisionTime": "2018-05-12T06:04:43Z"
+			"revision": "a7b61129ca818b3a2d1ebb3d276ed82b5b7eabfe",
+			"revisionTime": "2018-06-24T01:24:03Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",


### PR DESCRIPTION
Before creating a new `scaleway_server` instance, the availability is detected using the compute api specific `/products/servers/availability` API. 

Valid return values are (`available`, `scarce`, `shortage`), where `shortage` identifies out of stock.

In this case the provide will fail to create a new instance.

closes https://github.com/terraform-providers/terraform-provider-scaleway/issues/66 .