### PR TITLE
fix race-condition between server & volume_attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 1.6.0 (Unreleased)
+## 1.5.1 (Unreleased)
 
 IMPROVEMENTS:
 
 * provider: update documentation ([#75](https://github.com/terraform-providers/terraform-provider-scaleway/pull/75))
+
+BUG FIXES:
+
+* resource/scaleway_server & resource/scaleway_volume_attachment: race condition between startup & shutdown of servers ([#74](https://github.com/terraform-providers/terraform-provider-scaleway/pull/74))
 
 ## 1.5.0 (June 29, 2018)
 

--- a/scaleway/resource_ip_test.go
+++ b/scaleway/resource_ip_test.go
@@ -79,6 +79,7 @@ func TestAccScalewayIP_Basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckScalewayIPAttachConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayServerExists("scaleway_server.base"),
 					testAccCheckScalewayIPExists("scaleway_ip.base"),
 					testAccCheckScalewayIPAttachment("scaleway_ip.base", func(serverID string) bool {
 						return serverID != ""
@@ -204,7 +205,6 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  state = "stopped"
 }
 
 resource "scaleway_ip" "base" {

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -257,10 +257,8 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScalewayServerRead(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-	mu.Lock()
-	server, err := scaleway.GetServer(d.Id())
-	mu.Unlock()
 
+	server, err := scaleway.GetServer(d.Id())
 	if err != nil {
 		if serr, ok := err.(api.APIError); ok {
 			log.Printf("[DEBUG] Error reading server: %q\n", serr.APIMessage)
@@ -373,10 +371,7 @@ func resourceScalewayServerUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceScalewayServerDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
 	s, err := scaleway.GetServer(d.Id())
-	mu.Unlock()
-
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -236,14 +236,10 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(server.Identifier)
 	if d.Get("state").(string) != "stopped" {
-		mu.Lock()
-		task, err := scaleway.PostServerAction(server.Identifier, "poweron")
-		mu.Unlock()
+		err := startServer(scaleway, server)
 		if err != nil {
 			return err
 		}
-
-		err = waitForTaskCompletion(scaleway, task.Identifier)
 
 		if v, ok := d.GetOk("public_ip"); ok {
 			if err := attachIP(scaleway, d.Id(), v.(string)); err != nil {
@@ -390,7 +386,6 @@ func resourceScalewayServerDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	err = deleteRunningServer(scaleway, s)
-
 	if err == nil {
 		d.SetId("")
 	}

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -203,11 +203,13 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 			sizeInGB := uint64(volume["size_in_gb"].(int))
 
 			if sizeInGB > 0 {
+				mu.Lock()
 				v, err := scaleway.CreateVolume(api.VolumeDefinition{
 					Size: sizeInGB * gb,
 					Type: volume["type"].(string),
 					Name: fmt.Sprintf("%s-%d", req.Name, sizeInGB),
 				})
+				mu.Unlock()
 				if err != nil {
 					return err
 				}
@@ -259,7 +261,9 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScalewayServerRead(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
+	mu.Lock()
 	server, err := scaleway.GetServer(d.Id())
+	mu.Unlock()
 
 	if err != nil {
 		if serr, ok := err.(api.APIError); ok {
@@ -374,9 +378,9 @@ func resourceScalewayServerDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
 	mu.Lock()
-	defer mu.Unlock()
-
 	s, err := scaleway.GetServer(d.Id())
+	mu.Unlock()
+
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_server_test.go
+++ b/scaleway/resource_server_test.go
@@ -315,6 +315,10 @@ func testAccCheckScalewayServerExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Record not found")
 		}
 
+		if server.State != "running" {
+			return fmt.Errorf("expected server to be running, but was %q", server.State)
+		}
+
 		return nil
 	}
 }

--- a/scaleway/resource_user_data_test.go
+++ b/scaleway/resource_user_data_test.go
@@ -17,6 +17,7 @@ func TestAccScalewayUserData_Basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckScalewayUserDataConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayServerExists("scaleway_server.base"),
 					testAccCheckScalewayUserDataExists("scaleway_user_data.base"),
 					resource.TestCheckResourceAttr("scaleway_user_data.base", "value", "supersecret"),
 					resource.TestCheckResourceAttr("scaleway_user_data.base", "key", "gcp_username"),
@@ -69,7 +70,6 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  state = "stopped"
 }
 
 resource "scaleway_user_data" "base" {

--- a/scaleway/resource_volume_attachment.go
+++ b/scaleway/resource_volume_attachment.go
@@ -35,12 +35,12 @@ func resourceScalewayVolumeAttachment() *schema.Resource {
 var errVolumeAlreadyAttached = fmt.Errorf("Scaleway volume already attached")
 
 func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{}) error {
-	mu.Lock()
-	defer mu.Unlock()
-
 	scaleway := m.(*Client).scaleway
 
+	mu.Lock()
 	vol, err := scaleway.GetVolume(d.Get("volume").(string))
+	mu.Unlock()
+
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,9 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 			var req = api.ServerPatchDefinition{
 				Volumes: &volumes,
 			}
+			mu.Lock()
 			err := scaleway.PatchServer(server.Identifier, req)
+			mu.Unlock()
 
 			if err == nil {
 				return nil
@@ -141,9 +143,6 @@ func resourceScalewayVolumeAttachmentRead(d *schema.ResourceData, m interface{})
 const serverWaitTimeout = 5 * time.Minute
 
 func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{}) error {
-	mu.Lock()
-	defer mu.Unlock()
-
 	scaleway := m.(*Client).scaleway
 
 	if err := withStoppedServer(scaleway, d.Get("server").(string), func(server *api.Server) error {
@@ -171,7 +170,9 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 			var req = api.ServerPatchDefinition{
 				Volumes: &volumes,
 			}
+			mu.Lock()
 			err := scaleway.PatchServer(server.Identifier, req)
+			mu.Unlock()
 
 			if err == nil {
 				return nil

--- a/scaleway/resource_volume_attachment_test.go
+++ b/scaleway/resource_volume_attachment_test.go
@@ -17,6 +17,7 @@ func TestAccScalewayVolumeAttachment_Basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckScalewayVolumeAttachmentConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayServerExists("scaleway_server.base"),
 					testAccCheckScalewayVolumeAttachmentExists("scaleway_volume_attachment.test"),
 				),
 			},
@@ -76,7 +77,6 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  # state = "stopped"
 }
 
 resource "scaleway_volume" "test" {


### PR DESCRIPTION
#72 introduced a race condition when `volume_attachments` are used together with `server` resources, as the server might currently be starting/ stopping.

This PR introduces per-server wait groups to synchronise the different actions: all server stop/ start actions are now managed by `startServer` and `stopServer`, and these actions ensure that no server is concurrently being started/ stopped.

@meyskens would be great if you could verify that this fixes your issue.

Multiple test runs shows all tests are green:

```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?     github.com/terraform-providers/terraform-provider-scaleway  [no test files]
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (8.19s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (21.80s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (22.83s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (7.82s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (7.81s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (91.17s)
=== RUN   TestAccScalewayToken_importBasic
--- PASS: TestAccScalewayToken_importBasic (21.15s)
=== RUN   TestAccScalewayUserData_importBasic
--- PASS: TestAccScalewayUserData_importBasic (86.55s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (7.77s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccScalewayIP_Count
--- PASS: TestAccScalewayIP_Count (12.67s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (112.47s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (20.33s)
=== RUN   TestAccScalewaySecurityGroupRule_Count
--- PASS: TestAccScalewaySecurityGroupRule_Count (21.63s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (9.17s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (102.60s)
=== RUN   TestAccScalewayServer_BootType
--- PASS: TestAccScalewayServer_BootType (89.17s)
=== RUN   TestAccScalewayServer_ExistingIP
--- PASS: TestAccScalewayServer_ExistingIP (91.03s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (116.61s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (102.50s)
=== RUN   TestGetSSHKeyFingerprint
--- PASS: TestGetSSHKeyFingerprint (0.00s)
=== RUN   TestAccScalewaySSHKey_Basic
--- PASS: TestAccScalewaySSHKey_Basic (32.92s)
=== RUN   TestAccScalewayToken_Basic
--- PASS: TestAccScalewayToken_Basic (31.63s)
=== RUN   TestAccScalewayToken_Expiry
--- PASS: TestAccScalewayToken_Expiry (18.35s)
=== RUN   TestAccScalewayUserData_Basic
--- PASS: TestAccScalewayUserData_Basic (98.66s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (310.42s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (9.10s)
PASS
ok    github.com/terraform-providers/terraform-provider-scaleway/scaleway  1454.369s
```

besides the tests I also verified it's working properly with this terraform script:

```
provider "scaleway" {}

resource "scaleway_server" "base" {
  name = "test-${count.index}"

  count = 2
  image = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
  type  = "C1"
  tags  = ["terraform-test", "${count.index}"]

  volume {
    size_in_gb = 20
    type       = "l_ssd"
  }
}

resource "scaleway_volume" "test" {
  count      = 2
  name       = "test-${count.index}"
  size_in_gb = 5
  type       = "l_ssd"
}

resource "scaleway_volume_attachment" "test" {
  count = 2

  server = "${element(scaleway_server.base.*.id, count.index)}"
  volume = "${element(scaleway_volume.test.*.id, count.index)}"
}

```