### PR TITLE
Documentation edits

### DIFF
--- a/website/docs/d/bootscript.html.markdown
+++ b/website/docs/d/bootscript.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Scaleway bootscript.
 ---
 
-# scaleway\_bootscript
+# scaleway_bootscript
 
 Use this data source to get the ID of a registered Bootscript for use with the
 `scaleway_server` resource.
@@ -46,4 +46,3 @@ are exported:
 * `initrd` - URL to initial ramdisk content
 
 * `kernel` - URL to used kernel
-

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Scaleway image.
 ---
 
-# scaleway\_image
+# scaleway_image
 
 Use this data source to get the ID of a registered Image for use with the
 `scaleway_server` resource.
@@ -46,4 +46,3 @@ are exported:
 * `public` - is this a public image
 
 * `creation_date` - date when image was created
-

--- a/website/docs/r/ip.html.markdown
+++ b/website/docs/r/ip.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway IPs.
 ---
 
-# scaleway\_ip
+# scaleway_ip
 
 Provides IPs for servers. This allows IPs to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#ips).

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway security groups.
 ---
 
-# scaleway\_security\_group
+# scaleway_security_group
 
 Provides security groups. This allows security groups to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#security-groups).

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway security group rules.
 ---
 
-# scaleway\_security\_group\_rule
+# scaleway_security_group_rule
 
 Provides security group rules. This allows security group rules to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#security-groups-manage-rules).

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway servers.
 ---
 
-# scaleway\_server
+# scaleway_server
 
 Provides servers. This allows servers to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#servers).
@@ -52,16 +52,16 @@ Field `name`, `type`, `tags`, `dynamic_ip_required`, `security_group` are editab
 You can attach additional volumes to your instance, which will share the lifetime
 of your `scaleway_server` resource.
 
-**Warning:** Using the `volume` attribute does not modify the System Volume provided default with every `scaleway_server` instance.
-Instead it adds additional volumes to the server instance.
+~> **Warning:** Using the `volume` attribute does not modify the System Volume provided default with every `scaleway_server` instance. Instead it adds additional volumes to the server instance.
 
-**Warning:** Some instance types require an additional volume to work. This includes for example *START-1M* and *VC1M*.
-If you run into this issue add an additional volume of the specified size.
+~> **Warning:** Some instance types require an additional volume to work. This includes for example *START-1M* and *VC1M*. If you run into this issue add an additional volume of the specified size.
 
 The `volume` mapping supports the following:
 
 * `type` - (Required) The type of volume. Can be `"l_ssd"`
 * `size_in_gb` - (Required) The size of the volume in gigabytes.
+
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway user SSH keys.
 ---
 
-# scaleway\_ssh\_key
+# scaleway_ssh_key
 
 Manages user SSH Keys to access servers provisioned on scaleway.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#users-user-get).

--- a/website/docs/r/token.html.markdown
+++ b/website/docs/r/token.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway Tokens.
 ---
 
-# scaleway\_token
+# scaleway_token
 
 Provides Tokens for scaleway API access. For additional details please refer to [API documentation](https://developer.scaleway.com/#tokens-tokens-post).
 

--- a/website/docs/r/user_data.html.markdown
+++ b/website/docs/r/user_data.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway Server UserData.
 ---
 
-# scaleway\_user\_data
+# scaleway_user_data
 
 Provides user data for servers.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#user-data).

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages Scaleway Volumes.
 ---
 
-# scaleway\_volume
+# scaleway_volume
 
 Provides volumes. This allows volumes to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#volumes).

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -6,12 +6,11 @@ description: |-
   Manages Scaleway Volume attachments for servers.
 ---
 
-# scaleway\_volume\_attachment
+# scaleway_volume_attachment
 
 This allows volumes to be attached to servers.
 
-**Warning:** Attaching volumes requires the servers to be powered off. This will lead
-to downtime if the server is already in use.
+~> **Warning:** Attaching volumes requires the servers to be powered off. This will lead to downtime if the server is already in use.
 
 ## Example Usage
 


### PR DESCRIPTION
This PR fixes a couple of minor issues I noticed whilst scrolling through the docs:

- converts the `warning` boxes to yellow boxes to make them more prominent (you can use `->` for a blue info box / `~>` for a yellow info box)
- removes the backslashes from the resource names since they're not needed
- fixes the `attribute reference` title (the markdown parser needs a blank line either side)

<img width="719" alt="screenshot 2018-07-13 at 22 56 54" src="https://user-images.githubusercontent.com/666005/42713518-0d34e9f0-86f0-11e8-9551-f3cf7188c410.png">