### PR TITLE
New Data Source: `scaleway_volume`

### DIFF
--- a/scaleway/data_source_volume.go
+++ b/scaleway/data_source_volume.go
@@ -1,0 +1,81 @@
+package scaleway
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/nicolai86/scaleway-sdk"
+)
+
+func dataSourceScalewayVolume() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceScalewayVolumeRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "the name of the volume",
+			},
+			"size_in_gb": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "the size of the volume in GB",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the type of backing storage",
+			},
+			"server": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceScalewayVolumeRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client).scaleway
+
+	name := d.Get("name").(string)
+
+	volumes, err := client.GetVolumes()
+	if err != nil {
+		if serr, ok := err.(api.APIError); ok {
+			log.Printf("[DEBUG] Error obtaining Volumes: %q\n", serr.APIMessage)
+		}
+
+		return fmt.Errorf("Error obtaining Volumes: %+v", err)
+	}
+
+	var volume *api.Volume
+	for _, v := range *volumes {
+		if v.Name == name {
+			volume = &v
+			break
+		}
+	}
+
+	if volume == nil {
+		return fmt.Errorf("Couldn't locate a Volume with the name %q!", name)
+	}
+
+	d.SetId(volume.Identifier)
+
+	d.Set("name", volume.Name)
+	d.Set("size_in_gb", int(uint64(volume.Size)/gb))
+	d.Set("type", volume.VolumeType)
+
+	if volume.Server != nil {
+		d.Set("server", volume.Server.Identifier)
+	} else {
+		d.Set("server", "")
+	}
+
+	return nil
+}

--- a/scaleway/data_source_volume.go
+++ b/scaleway/data_source_volume.go
@@ -11,9 +11,6 @@ import (
 func dataSourceScalewayVolume() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceScalewayVolumeRead,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/scaleway/data_source_volume_test.go
+++ b/scaleway/data_source_volume_test.go
@@ -1,0 +1,41 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewayDataSourceVolume_Basic(t *testing.T) {
+	dataSourceName := "data.scaleway_volume.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckScalewayDataSourceVolumeConfig(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayVolumeExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "size_in_gb", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "l_ssd"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayDataSourceVolumeConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "scaleway_volume" "test" {
+  name = "test%d"
+  size_in_gb = 2
+  type = "l_ssd"
+}
+
+data "scaleway_volume" "test" {
+  name = "${scaleway_volume.test.name}"
+}
+`, rInt)
+}

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"scaleway_bootscript": dataSourceScalewayBootscript(),
 			"scaleway_image":      dataSourceScalewayImage(),
+			"scaleway_volume":     dataSourceScalewayVolume(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/vendor/github.com/hashicorp/terraform/helper/acctest/acctest.go
+++ b/vendor/github.com/hashicorp/terraform/helper/acctest/acctest.go
@@ -1,0 +1,2 @@
+// Package acctest contains for Terraform Acceptance Tests
+package acctest

--- a/vendor/github.com/hashicorp/terraform/helper/acctest/random.go
+++ b/vendor/github.com/hashicorp/terraform/helper/acctest/random.go
@@ -1,0 +1,145 @@
+package acctest
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Helpers for generating random tidbits for use in identifiers to prevent
+// collisions in acceptance tests.
+
+// RandInt generates a random integer
+func RandInt() int {
+	reseed()
+	return rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+}
+
+// RandomWithPrefix is used to generate a unique name with a prefix, for
+// randomizing names in acceptance tests
+func RandomWithPrefix(name string) string {
+	reseed()
+	return fmt.Sprintf("%s-%d", name, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}
+
+func RandIntRange(min int, max int) int {
+	reseed()
+	source := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rangeMax := max - min
+
+	return int(source.Int31n(int32(rangeMax)))
+}
+
+// RandString generates a random alphanumeric string of the length specified
+func RandString(strlen int) string {
+	return RandStringFromCharSet(strlen, CharSetAlphaNum)
+}
+
+// RandStringFromCharSet generates a random string by selecting characters from
+// the charset provided
+func RandStringFromCharSet(strlen int, charSet string) string {
+	reseed()
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = charSet[rand.Intn(len(charSet))]
+	}
+	return string(result)
+}
+
+// RandSSHKeyPair generates a public and private SSH key pair. The public key is
+// returned in OpenSSH format, and the private key is PEM encoded.
+func RandSSHKeyPair(comment string) (string, string, error) {
+	privateKey, privateKeyPEM, err := genPrivateKey()
+	if err != nil {
+		return "", "", err
+	}
+
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return "", "", err
+	}
+	keyMaterial := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(publicKey)))
+	return fmt.Sprintf("%s %s", keyMaterial, comment), privateKeyPEM, nil
+}
+
+// RandTLSCert generates a self-signed TLS certificate with a newly created
+// private key, and returns both the cert and the private key PEM encoded.
+func RandTLSCert(orgName string) (string, string, error) {
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(int64(RandInt())),
+		Subject: pkix.Name{
+			Organization: []string{orgName},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	privateKey, privateKeyPEM, err := genPrivateKey()
+	if err != nil {
+		return "", "", err
+	}
+
+	cert, err := x509.CreateCertificate(crand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	certPEM, err := pemEncode(cert, "CERTIFICATE")
+	if err != nil {
+		return "", "", err
+	}
+
+	return certPEM, privateKeyPEM, nil
+}
+
+func genPrivateKey() (*rsa.PrivateKey, string, error) {
+	privateKey, err := rsa.GenerateKey(crand.Reader, 1024)
+	if err != nil {
+		return nil, "", err
+	}
+
+	privateKeyPEM, err := pemEncode(x509.MarshalPKCS1PrivateKey(privateKey), "RSA PRIVATE KEY")
+	if err != nil {
+		return nil, "", err
+	}
+
+	return privateKey, privateKeyPEM, nil
+}
+
+func pemEncode(b []byte, block string) (string, error) {
+	var buf bytes.Buffer
+	pb := &pem.Block{Type: block, Bytes: b}
+	if err := pem.Encode(&buf, pb); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// Seeds random with current timestamp
+func reseed() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+const (
+	// CharSetAlphaNum is the alphanumeric character set for use with
+	// RandStringFromCharSet
+	CharSetAlphaNum = "abcdefghijklmnopqrstuvwxyz012346789"
+
+	// CharSetAlpha is the alphabetical character set for use with
+	// RandStringFromCharSet
+	CharSetAlpha = "abcdefghijklmnopqrstuvwxyz"
+)

--- a/vendor/github.com/hashicorp/terraform/helper/acctest/remotetests.go
+++ b/vendor/github.com/hashicorp/terraform/helper/acctest/remotetests.go
@@ -1,0 +1,27 @@
+package acctest
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+// SkipRemoteTestsEnvVar is an environment variable that can be set by a user
+// running the tests in an environment with limited network connectivity. By
+// default, tests requiring internet connectivity make an effort to skip if no
+// internet is available, but in some cases the smoke test will pass even
+// though the test should still be skipped.
+const SkipRemoteTestsEnvVar = "TF_SKIP_REMOTE_TESTS"
+
+// RemoteTestPrecheck is meant to be run by any unit test that requires
+// outbound internet connectivity. The test will be skipped if it's
+// unavailable.
+func RemoteTestPrecheck(t *testing.T) {
+	if os.Getenv(SkipRemoteTestsEnvVar) != "" {
+		t.Skipf("skipping test, %s was set", SkipRemoteTestsEnvVar)
+	}
+
+	if _, err := http.Get("http://google.com"); err != nil {
+		t.Skipf("skipping, internet seems to not be available: %s", err)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -414,6 +414,14 @@
 			"versionExact": "v0.10.0"
 		},
 		{
+			"checksumSHA1": "zx5DLo5aV0xDqxGTzSibXg7HHAA=",
+			"path": "github.com/hashicorp/terraform/helper/acctest",
+			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
+			"revisionTime": "2017-08-02T18:39:14Z",
+			"version": "v0.10.0",
+			"versionExact": "v0.10.0"
+		},
+		{
 			"checksumSHA1": "uT6Q9RdSRAkDjyUgQlJ2XKJRab4=",
 			"path": "github.com/hashicorp/terraform/helper/config",
 			"revision": "2041053ee9444fa8175a298093b55a89586a1823",

--- a/website/docs/d/volume.html.markdown
+++ b/website/docs/d/volume.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: scaleway_volume"
+sidebar_current: "docs-scaleway-datasource-volume"
+description: |-
+  Gets information about a Volume.
+---
+
+# scaleway_volume
+
+Gets information about a Volume.
+
+## Example Usage
+
+```hcl
+data "scaleway_volume" "data" {
+  name = "data"
+}
+
+resource "scaleway_server" "test" {
+  # ...
+}
+
+resource "scaleway_volume_attachment" "data" {
+  server = "${scaleway_server.test.id}"
+  volume = "${scaleway_volume.data.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Exact name of the Volume.
+
+## Attributes Reference
+
+`id` is set to the ID of the found Volume. In addition, the following attributes
+are exported:
+
+
+* `size_in_gb` - (Required) size of the volume in GB
+* `type` - The type of volume this is, such as `l_ssd`.
+* `server` - The ID of the Server which this Volume is currently attached to.

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -35,13 +35,14 @@ The following arguments are supported:
 * `name` - (Required) name of volume
 * `size_in_gb` - (Required) size of the volume in GB
 * `type` - (Required) type of volume
-* `server` - (Read Only) the `scaleway_server` instance which has this volume mounted right now
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - id of the new resource
+
+* `server` - (Read Only) the `scaleway_server` instance which has this volume mounted right now
 
 ## Import
 

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-scaleway-datasource-image") %>>
               <a href="/docs/providers/scaleway/d/image.html">scaleway_image</a>
             </li>
+            <li<%= sidebar_current("docs-scaleway-datasource-volume") %>>
+              <a href="/docs/providers/scaleway/d/volume.html">scaleway_volume</a>
+            </li>
           </ul>
         </li>
 

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -31,23 +31,23 @@
             <li<%= sidebar_current("docs-scaleway-resource-ip") %>>
               <a href="/docs/providers/scaleway/r/ip.html">scaleway_ip</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-server") %>>
-              <a href="/docs/providers/scaleway/r/server.html">scaleway_server</a>
-            </li>
             <li<%= sidebar_current("docs-scaleway-resource-security_group") %>>
               <a href="/docs/providers/scaleway/r/security_group.html">scaleway_security_group</a>
             </li>
             <li<%= sidebar_current("docs-scaleway-resource-security_group_rule") %>>
               <a href="/docs/providers/scaleway/r/security_group_rule.html">scaleway_security_group_rule</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-volume") %>>
-              <a href="/docs/providers/scaleway/r/volume.html">scaleway_volume</a>
+            <li<%= sidebar_current("docs-scaleway-resource-server") %>>
+              <a href="/docs/providers/scaleway/r/server.html">scaleway_server</a>
             </li>
             <li<%= sidebar_current("docs-scaleway-resource-token") %>>
               <a href="/docs/providers/scaleway/r/token.html">scaleway_token</a>
             </li>
             <li<%= sidebar_current("docs-scaleway-resource-user_data") %>>
               <a href="/docs/providers/scaleway/r/user_data.html">scaleway_user_data</a>
+            </li>
+            <li<%= sidebar_current("docs-scaleway-resource-volume") %>>
+              <a href="/docs/providers/scaleway/r/volume.html">scaleway_volume</a>
             </li>
             <li<%= sidebar_current("docs-scaleway-resource-volume_attachment") %>>
               <a href="/docs/providers/scaleway/r/volume_attachment.html">scaleway_volume_attachment</a>


### PR DESCRIPTION
Used for querying an existing Scaleway volume by it's name:

```
data "scaleway_volume" "test" {
  name = "some-data"
}
```