### PR TITLE
New Data Source: `scaleway_security_group`

### DIFF
--- a/scaleway/data_source_security_group.go
+++ b/scaleway/data_source_security_group.go
@@ -1,0 +1,65 @@
+package scaleway
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/nicolai86/scaleway-sdk"
+)
+
+func dataSourceScalewaySecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceScalewaySecurityGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the security group",
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_default_security": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+func dataSourceScalewaySecurityGroupRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client).scaleway
+
+	groups, err := client.GetSecurityGroups()
+	if err != nil {
+		if serr, ok := err.(api.APIError); ok {
+			log.Printf("[DEBUG] Error reading Security Groups: %q\n", serr.APIMessage)
+		}
+
+		return err
+	}
+
+	name := d.Get("name").(string)
+
+	var group *api.SecurityGroup
+	for _, v := range groups {
+		if v.Name == name {
+			group = &v
+			break
+		}
+	}
+
+	if group == nil {
+		return fmt.Errorf("Security Group with name %q was not found!", name)
+	}
+
+	d.SetId(group.ID)
+
+	d.Set("name", group.Name)
+	d.Set("description", group.Description)
+	d.Set("enable_default_security", group.EnableDefaultSecurity)
+
+	return nil
+}

--- a/scaleway/data_source_security_group_test.go
+++ b/scaleway/data_source_security_group_test.go
@@ -1,0 +1,43 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewaySecurityGroupDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.scaleway_security_group.test"
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewaySecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckScalewayDataSourceSecurityGroupConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewaySecurityGroupExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("test%d", ri)),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "public gateway"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayDataSourceSecurityGroupConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "scaleway_security_group" "test" {
+  name = "test%d"
+  description = "public gateway"
+}
+
+data "scaleway_security_group" "test" {
+  name = "${scaleway_security_group.test.name}"
+}
+`, rInt)
+}

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -56,9 +56,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"scaleway_bootscript": dataSourceScalewayBootscript(),
-			"scaleway_image":      dataSourceScalewayImage(),
-			"scaleway_volume":     dataSourceScalewayVolume(),
+			"scaleway_bootscript":     dataSourceScalewayBootscript(),
+			"scaleway_image":          dataSourceScalewayImage(),
+			"scaleway_security_group": dataSourceScalewaySecurityGroup(),
+			"scaleway_volume":         dataSourceScalewayVolume(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/scaleway/resource_security_group_test.go
+++ b/scaleway/resource_security_group_test.go
@@ -49,7 +49,7 @@ func TestAccScalewaySecurityGroup_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckScalewaySecurityGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckScalewaySecurityGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewaySecurityGroupExists("scaleway_security_group.base"),

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: scaleway_security_group"
+sidebar_current: "docs-scaleway-datasource-security-group"
+description: |-
+  Gets information about a Security Group.
+---
+
+# scaleway_security_group
+
+Gets information about a Security Group.
+
+## Example Usage
+
+```hcl
+data "scaleway_security_group" "test" {
+  name = "my-security-group"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional) Exact name of desired Security Group
+
+## Attributes Reference
+
+`id` is set to the ID of the found Image. In addition, the following attributes
+are exported:
+
+* `description` - description of the security group
+* `enable_default_security` - have default security group rules been added to this security group?

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -20,7 +20,7 @@ data "scaleway_security_group" "test" {
 
 ## Argument Reference
 
-* `name` - (Optional) Exact name of desired Security Group
+* `name` - (Required) Exact name of desired Security Group
 
 ## Attributes Reference
 

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-scaleway-datasource-image") %>>
               <a href="/docs/providers/scaleway/d/image.html">scaleway_image</a>
             </li>
+            <li<%= sidebar_current("docs-scaleway-datasource-security-group") %>>
+              <a href="/docs/providers/scaleway/d/security_group.html">scaleway_security_group</a>
+            </li>
             <li<%= sidebar_current("docs-scaleway-datasource-volume") %>>
               <a href="/docs/providers/scaleway/d/volume.html">scaleway_volume</a>
             </li>


### PR DESCRIPTION
Allows retrieving information about a given Security Group. Usage:

```hcl
data "scaleway_security_group" "test" {
  name = "my-security-group"
}
```


```
$ acctests scaleway TestAccScalewaySecurityGroupDataSource_Basic
=== RUN   TestAccScalewaySecurityGroupDataSource_Basic
[DEBUG] GET https://cp-par1.scaleway.com//products/servers/availability
[DEBUG] POST https://cp-par1.scaleway.com/security_groups
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d
[DEBUG] HEAD https://cp-par1.scaleway.com/security_groups?
[DEBUG] GET https://cp-par1.scaleway.com/security_groups
[DEBUG] DELETE https://cp-par1.scaleway.com/security_groups/4cb41897-530c-457f-8419-007dedfe268d
--- PASS: TestAccScalewaySecurityGroupDataSource_Basic (13.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	13.872s
```