### PR TITLE
Docs: fixing the sidebar highlight

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: security_group"
-sidebar_current: "docs-scaleway-resource-security_group"
+sidebar_current: "docs-scaleway-resource-security-group-x"
 description: |-
   Manages Scaleway security groups.
 ---

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: security_group_rule"
-sidebar_current: "docs-scaleway-resource-security_group_rule"
+sidebar_current: "docs-scaleway-resource-security-group-rule"
 description: |-
   Manages Scaleway security group rules.
 ---

--- a/website/docs/r/user_data.html.markdown
+++ b/website/docs/r/user_data.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: user_data"
-sidebar_current: "docs-scaleway-resource-user_data"
+sidebar_current: "docs-scaleway-resource-user-data"
 description: |-
   Manages Scaleway Server UserData.
 ---

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: volume"
-sidebar_current: "docs-scaleway-resource-volume"
+sidebar_current: "docs-scaleway-resource-volume-x"
 description: |-
   Manages Scaleway Volumes.
 ---

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: volume attachment"
-sidebar_current: "docs-scaleway-resource-volume attachment"
+sidebar_current: "docs-scaleway-resource-volume-attachment"
 description: |-
   Manages Scaleway Volume attachments for servers.
 ---

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -43,6 +43,9 @@
             <li<%= sidebar_current("docs-scaleway-resource-server") %>>
               <a href="/docs/providers/scaleway/r/server.html">scaleway_server</a>
             </li>
+            <li<%= sidebar_current("docs-scaleway-resource-ssh-key") %>>
+              <a href="/docs/providers/scaleway/r/ssh_key.html">scaleway_ssh_key</a>
+            </li>
             <li<%= sidebar_current("docs-scaleway-resource-token") %>>
               <a href="/docs/providers/scaleway/r/token.html">scaleway_token</a>
             </li>

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -19,9 +19,6 @@
             <li<%= sidebar_current("docs-scaleway-datasource-image") %>>
               <a href="/docs/providers/scaleway/d/image.html">scaleway_image</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-datasource-security-group") %>>
-              <a href="/docs/providers/scaleway/d/security_group.html">scaleway_security_group</a>
-            </li>
             <li<%= sidebar_current("docs-scaleway-datasource-volume") %>>
               <a href="/docs/providers/scaleway/d/volume.html">scaleway_volume</a>
             </li>

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-scaleway-datasource-image") %>>
               <a href="/docs/providers/scaleway/d/image.html">scaleway_image</a>
             </li>
+            <li<%= sidebar_current("docs-scaleway-datasource-security-group") %>>
+              <a href="/docs/providers/scaleway/d/security_group.html">scaleway_security_group</a>
+            </li>
             <li<%= sidebar_current("docs-scaleway-datasource-volume") %>>
               <a href="/docs/providers/scaleway/d/volume.html">scaleway_volume</a>
             </li>
@@ -31,10 +34,10 @@
             <li<%= sidebar_current("docs-scaleway-resource-ip") %>>
               <a href="/docs/providers/scaleway/r/ip.html">scaleway_ip</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-security_group") %>>
+            <li<%= sidebar_current("docs-scaleway-resource-security-group") %>>
               <a href="/docs/providers/scaleway/r/security_group.html">scaleway_security_group</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-security_group_rule") %>>
+            <li<%= sidebar_current("docs-scaleway-resource-security-group-rule") %>>
               <a href="/docs/providers/scaleway/r/security_group_rule.html">scaleway_security_group_rule</a>
             </li>
             <li<%= sidebar_current("docs-scaleway-resource-server") %>>
@@ -43,13 +46,13 @@
             <li<%= sidebar_current("docs-scaleway-resource-token") %>>
               <a href="/docs/providers/scaleway/r/token.html">scaleway_token</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-user_data") %>>
+            <li<%= sidebar_current("docs-scaleway-resource-user-data") %>>
               <a href="/docs/providers/scaleway/r/user_data.html">scaleway_user_data</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-volume") %>>
+            <li<%= sidebar_current("docs-scaleway-resource-volume-x") %>>
               <a href="/docs/providers/scaleway/r/volume.html">scaleway_volume</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-volume_attachment") %>>
+            <li<%= sidebar_current("docs-scaleway-resource-volume-attachment") %>>
               <a href="/docs/providers/scaleway/r/volume_attachment.html">scaleway_volume_attachment</a>
             </li>
           </ul>


### PR DESCRIPTION
Noticed the sidebar didn't highlight correctly for the Security Groups / Volume attachment resources

<img width="287" alt="screenshot 2018-07-14 at 09 17 35" src="https://user-images.githubusercontent.com/666005/42722141-0dc8fc24-8747-11e8-97ec-dadd65e5927d.png">



This PR also adds the SSH Key Resource to the sidebar, since it's currently missing