### PR TITLE
d/image: add most_recent filter to support multiple matches

### DIFF
--- a/scaleway/data_source_image.go
+++ b/scaleway/data_source_image.go
@@ -24,10 +24,11 @@ func dataSourceScalewayImage() *schema.Resource {
 				Description: "exact name of the desired image",
 			},
 			"name_filter": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "partial name of the desired image to filter with",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Description:   "partial name of the desired image to filter with",
+				ConflictsWith: []string{"most_recent"},
 			},
 			"architecture": {
 				Type:        schema.TypeString,
@@ -36,11 +37,12 @@ func dataSourceScalewayImage() *schema.Resource {
 				Description: "architecture of the desired image",
 			},
 			"most_recent": {
-				Type:        schema.TypeBool,
-				Required:    false,
-				Default:     false,
-				Optional:    true,
-				Description: "select most recent image if multiple match",
+				Type:          schema.TypeBool,
+				Required:      false,
+				Default:       false,
+				Optional:      true,
+				Description:   "select most recent image if multiple match",
+				ConflictsWith: []string{"name_filter"},
 			},
 			// Computed values.
 			"organization": {

--- a/scaleway/data_source_image.go
+++ b/scaleway/data_source_image.go
@@ -38,8 +38,6 @@ func dataSourceScalewayImage() *schema.Resource {
 			},
 			"most_recent": {
 				Type:          schema.TypeBool,
-				Required:      false,
-				Default:       false,
 				Optional:      true,
 				Description:   "select most recent image if multiple match",
 				ConflictsWith: []string{"name_filter"},

--- a/scaleway/data_source_image_test.go
+++ b/scaleway/data_source_image_test.go
@@ -27,6 +27,25 @@ func TestAccScalewayDataSourceImage_Basic(t *testing.T) {
 	})
 }
 
+func TestAccScalewayDataSourceImage_MostRecent(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayImageConfig_mostRecent,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageID("data.scaleway_image.ubuntu"),
+					resource.TestCheckResourceAttr("data.scaleway_image.ubuntu", "architecture", "arm"),
+					resource.TestCheckResourceAttr("data.scaleway_image.ubuntu", "public", "true"),
+					resource.TestCheckResourceAttrSet("data.scaleway_image.ubuntu", "organization"),
+					resource.TestCheckResourceAttrSet("data.scaleway_image.ubuntu", "creation_date"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccScalewayDataSourceImage_Filtered(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -73,6 +92,14 @@ const testAccCheckScalewayImageConfig = `
 data "scaleway_image" "ubuntu" {
   name = "Ubuntu Precise"
   architecture = "arm"
+}
+`
+
+const testAccCheckScalewayImageConfig_mostRecent = `
+data "scaleway_image" "ubuntu" {
+  name = "Ubuntu Xenial"
+  architecture = "arm"
+  most_recent = true
 }
 `
 

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -34,7 +34,7 @@ resource "scaleway_server" "base" {
 
 * `name` - (Optional) Exact name of desired Image
 
-* `most_recent` - (Optional) Return most recent image if multiple exist
+* `most_recent` - (Optional) Return most recent image if multiple exist. Can not be used together with name_filter.
 
 ## Attributes Reference
 

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -34,6 +34,8 @@ resource "scaleway_server" "base" {
 
 * `name` - (Optional) Exact name of desired Image
 
+* `most_recent` - (Optional) Return most recent image if multiple exist
+
 ## Attributes Reference
 
 `id` is set to the ID of the found Image. In addition, the following attributes


### PR DESCRIPTION
once merged fixes #81.

Now the data source for images supports `most_recent` to only return the most recent image if multiple matches exist:

```
provider "scaleway" {
  region       = "ams1"
}

data "scaleway_image" "ubuntu" {
  architecture = "x86_64"
  name         = "Ubuntu Xenial"
  most_recent  = true
}

output "image_id" {
  value = "${data.scaleway_image.ubuntu.id}" # will be ca9a9340-92e8-4c5f-8ae1-423466f7ef30 for AMS1
}

```