### PR TITLE
fix token API not returning IDs anymore

### DIFF
--- a/scaleway/resource_token.go
+++ b/scaleway/resource_token.go
@@ -36,6 +36,7 @@ func resourceScalewayToken() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The secret_key.",
+				Sensitive:   true,
 			},
 			"creation_ip": {
 				Type:        schema.TypeString,

--- a/scaleway/resource_token.go
+++ b/scaleway/resource_token.go
@@ -27,6 +27,21 @@ func resourceScalewayToken() *schema.Resource {
 				Computed:    true,
 				Description: "The userid of the associated user.",
 			},
+			"access_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The access_key.",
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret_key.",
+			},
+			"creation_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ip used to create the key.",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -99,6 +114,9 @@ func resourceScalewayTokenRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("expiration_date", token.Expires)
 	d.Set("expires", token.Expires != "")
 	d.Set("user_id", token.UserID)
+	d.Set("creation_ip", token.CreationIP)
+	d.Set("access_key", token.AccessKey)
+	d.Set("secret_key", token.SecretKey)
 	user, err := scaleway.GetUser()
 	if err != nil {
 		return err

--- a/scaleway/resource_token_test.go
+++ b/scaleway/resource_token_test.go
@@ -53,6 +53,9 @@ func TestAccScalewayToken_Basic(t *testing.T) {
 						"scaleway_token.base", "description", "just a test"),
 					resource.TestCheckResourceAttr(
 						"scaleway_token.base", "expires", "false"),
+					resource.TestCheckResourceAttrSet("scaleway_token.base", "access_key"),
+					resource.TestCheckResourceAttrSet("scaleway_token.base", "secret_key"),
+					resource.TestCheckResourceAttrSet("scaleway_token.base", "creation_ip"),
 				),
 			},
 			resource.TestStep{
@@ -129,7 +132,7 @@ func testAccCheckScalewayTokenExists(n string) resource.TestCheckFunc {
 		}
 
 		if token.ID != rs.Primary.ID {
-			return fmt.Errorf("Record not found")
+			return fmt.Errorf("Expected %q, got %q", rs.Primary.ID, token.ID)
 		}
 
 		return nil

--- a/vendor/github.com/nicolai86/scaleway-sdk/tokens.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/tokens.go
@@ -10,6 +10,10 @@ import (
 // Token represents a  Token
 type Token struct {
 	UserID             string `json:"user_id"`
+	AccessKey          string `json:"access_key"`
+	SecretKey          string `json:"secret_key"`
+	Category           string `json:"category"`
+	CreationIP         string `json:"creation_ip"`
 	Description        string `json:"description,omitempty"`
 	Roles              Role   `json:"roles"`
 	Expires            string `json:"expires"`
@@ -99,6 +103,7 @@ func (s *API) UpdateToken(req *UpdateTokenRequest) (*Token, error) {
 	if err = json.Unmarshal(body, &data); err != nil {
 		return nil, err
 	}
+	data.Token.ID = req.ID
 	return &data.Token, nil
 }
 
@@ -119,6 +124,7 @@ func (s *API) GetToken(id string) (*Token, error) {
 	if err = json.Unmarshal(body, &data); err != nil {
 		return nil, err
 	}
+	data.Token.ID = id
 	return &data.Token, nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -578,10 +578,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "w5i5Tximdwrgf2TDbyVr0KmNO9Q=",
+			"checksumSHA1": "Aw1tHFrJM6tp6d0taTozZPd3RPw=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "798f60e20bb2466bc3d8f36f1cf4f98410e49b6a",
-			"revisionTime": "2018-06-28T01:02:48Z"
+			"revision": "56991d7abc819253a234bfdf847add638b75749c",
+			"revisionTime": "2018-08-06T04:29:30Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/token.html.markdown
+++ b/website/docs/r/token.html.markdown
@@ -33,6 +33,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - Token ID - can be used to access scaleway API
+* `access_key` - Token Access Key
+* `secret_key` - Token Secret Key
+* `creation_ip` - IP used to create the token
 * `expiration_date` - Expiration date of token, if expiration is requested
 
 ## Import


### PR DESCRIPTION
Scaleway recently overhauled their token API - now there are a couple of changes:

- there are two new attributes: `access_key` and `secret_key`.
- the `ID` is no longer present in the response payload. It seems it has been deprecated in favor of `access_key`
- Fetching keys can be done by the AccessKey instead of the ID, too.

To make this a non-breaking change the SDK now sets the ID when reading with a specific ID.

Note that due to the API changes on Scaleway's side the tests are broken without this change.

All tests are green (together with #87)

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (9.80s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (24.92s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (23.04s)
=== RUN   TestAccScalewaySecurityGroupDataSource_Basic
--- PASS: TestAccScalewaySecurityGroupDataSource_Basic (14.17s)
=== RUN   TestAccScalewayDataSourceVolume_Basic
--- PASS: TestAccScalewayDataSourceVolume_Basic (12.13s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (8.47s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (8.45s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (80.53s)
=== RUN   TestAccScalewayToken_importBasic
--- PASS: TestAccScalewayToken_importBasic (22.79s)
=== RUN   TestAccScalewayUserData_importBasic
--- PASS: TestAccScalewayUserData_importBasic (100.06s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (7.86s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccScalewayIP_Count
--- PASS: TestAccScalewayIP_Count (13.14s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (128.85s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (18.78s)
=== RUN   TestAccScalewaySecurityGroupRule_Count
--- PASS: TestAccScalewaySecurityGroupRule_Count (18.80s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (10.49s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (239.57s)
=== RUN   TestAccScalewayServer_BootType
--- PASS: TestAccScalewayServer_BootType (67.89s)
=== RUN   TestAccScalewayServer_ExistingIP
--- PASS: TestAccScalewayServer_ExistingIP (104.61s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (108.64s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (104.55s)
=== RUN   TestGetSSHKeyFingerprint
--- PASS: TestGetSSHKeyFingerprint (0.00s)
=== RUN   TestAccScalewaySSHKey_Basic
--- PASS: TestAccScalewaySSHKey_Basic (35.92s)
=== RUN   TestAccScalewayToken_Basic
--- PASS: TestAccScalewayToken_Basic (35.22s)
=== RUN   TestAccScalewayToken_Expiry
--- PASS: TestAccScalewayToken_Expiry (19.28s)
=== RUN   TestAccScalewayUserData_Basic
--- PASS: TestAccScalewayUserData_Basic (100.39s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (312.07s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (9.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	1639.632s
```