### PR TITLE
fix server recreation with changed image_id

### DIFF
--- a/scaleway/helpers.go
+++ b/scaleway/helpers.go
@@ -46,6 +46,57 @@ func validateVolumeType(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+var allStates = []string{"starting", "running", "stopping", "stopped"}
+
+func waitForServerShutdown(scaleway *api.API, serverID string) error {
+	return waitForServerState(scaleway, serverID, "stopped", []string{"stopped", "stopping"})
+}
+
+func waitForServerStartup(scaleway *api.API, serverID string) error {
+	return waitForServerState(scaleway, serverID, "running", []string{"running", "starting"})
+}
+
+func waitForServerState(scaleway *api.API, serverID, targetState string, pendingStates []string) error {
+	wg := getWaitForServerLock(serverID)
+	wg.Wait()
+
+	mu.Lock()
+	wg.Add(1)
+	mu.Unlock()
+
+	defer func() {
+		mu.Lock()
+		wg.Done()
+		mu.Unlock()
+	}()
+
+	stateConf := &resource.StateChangeConf{
+		Pending: pendingStates,
+		Target:  []string{targetState},
+		Refresh: func() (interface{}, string, error) {
+			s, err := scaleway.GetServer(serverID)
+			if err == nil {
+				return 42, s.State, nil
+			}
+			if serr, ok := err.(api.APIError); ok {
+				if serr.StatusCode == 404 {
+					return 42, "stopped", nil
+				}
+			}
+			if s != nil {
+				return 42, s.State, err
+			}
+			return 42, "error", err
+		},
+		Timeout:    60 * time.Minute,
+		MinTimeout: 10 * time.Second,
+		Delay:      15 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
 var waitForServer = map[string]*sync.WaitGroup{}
 
 func getWaitForServerLock(serverID string) *sync.WaitGroup {
@@ -93,9 +144,7 @@ func deleteRunningServer(scaleway *api.API, server *api.Server) error {
 	wg := getWaitForServerLock(server.Identifier)
 	wg.Wait()
 
-	mu.Lock()
-	task, err := scaleway.PostServerAction(server.Identifier, "terminate")
-	mu.Unlock()
+	_, err := scaleway.PostServerAction(server.Identifier, "terminate")
 
 	if err != nil {
 		if serr, ok := err.(api.APIError); ok {
@@ -107,7 +156,7 @@ func deleteRunningServer(scaleway *api.API, server *api.Server) error {
 		return err
 	}
 
-	return waitForTaskCompletion(scaleway, task.Identifier, server.Identifier)
+	return waitForServerShutdown(scaleway, server.Identifier)
 }
 
 // deleteStoppedServer needs to cleanup attached root volumes. this is not done
@@ -165,9 +214,10 @@ func waitForTaskCompletion(scaleway *api.API, taskID, serverID string) error {
 }
 
 func withStoppedServer(scaleway *api.API, serverID string, run func(*api.Server) error) error {
-	mu.Lock()
+	wg := getWaitForServerLock(serverID)
+	wg.Wait()
+
 	server, err := scaleway.GetServer(serverID)
-	mu.Unlock()
 
 	if err != nil {
 		return err

--- a/scaleway/resource_ip.go
+++ b/scaleway/resource_ip.go
@@ -41,9 +41,7 @@ func resourceScalewayIP() *schema.Resource {
 func resourceScalewayIPCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
 	ip, err := scaleway.CreateIP()
-	mu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -81,9 +79,6 @@ func resourceScalewayIPRead(d *schema.ResourceData, m interface{}) error {
 func resourceScalewayIPUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	if d.HasChange("reverse") {
 		log.Printf("[DEBUG] Updating IP %q reverse to %q\n", d.Id(), d.Get("reverse").(string))
 		ip, err := scaleway.UpdateIP(api.UpdateIPRequest{
@@ -117,9 +112,6 @@ func resourceScalewayIPUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScalewayIPDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err := scaleway.DeleteIP(d.Id())
 	if err != nil {

--- a/scaleway/resource_security_group.go
+++ b/scaleway/resource_security_group.go
@@ -43,9 +43,6 @@ func resourceScalewaySecurityGroup() *schema.Resource {
 func resourceScalewaySecurityGroupCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	req := api.NewSecurityGroup{
 		Name:                  d.Get("name").(string),
 		Description:           d.Get("description").(string),
@@ -98,9 +95,6 @@ func resourceScalewaySecurityGroupRead(d *schema.ResourceData, m interface{}) er
 func resourceScalewaySecurityGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	var req = api.UpdateSecurityGroup{
 		Organization: scaleway.Organization,
 		Name:         d.Get("name").(string),
@@ -118,9 +112,6 @@ func resourceScalewaySecurityGroupUpdate(d *schema.ResourceData, m interface{}) 
 
 func resourceScalewaySecurityGroupDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err := scaleway.DeleteSecurityGroup(d.Id())
 	if err != nil {

--- a/scaleway/resource_security_group_rule.go
+++ b/scaleway/resource_security_group_rule.go
@@ -73,9 +73,6 @@ func resourceScalewaySecurityGroupRule() *schema.Resource {
 func resourceScalewaySecurityGroupRuleCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	req := api.NewSecurityGroupRule{
 		Action:       d.Get("action").(string),
 		Direction:    d.Get("direction").(string),
@@ -131,9 +128,6 @@ func resourceScalewaySecurityGroupRuleRead(d *schema.ResourceData, m interface{}
 func resourceScalewaySecurityGroupRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	var req = api.UpdateSecurityGroupRule{
 		Action:       d.Get("action").(string),
 		Direction:    d.Get("direction").(string),
@@ -153,9 +147,6 @@ func resourceScalewaySecurityGroupRuleUpdate(d *schema.ResourceData, m interface
 
 func resourceScalewaySecurityGroupRuleDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err := scaleway.DeleteSecurityGroupRule(d.Get("security_group").(string), d.Id())
 	if err != nil {

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -203,13 +203,11 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 			sizeInGB := uint64(volume["size_in_gb"].(int))
 
 			if sizeInGB > 0 {
-				mu.Lock()
 				v, err := scaleway.CreateVolume(api.VolumeDefinition{
 					Size: sizeInGB * gb,
 					Type: volume["type"].(string),
 					Name: fmt.Sprintf("%s-%d", req.Name, sizeInGB),
 				})
-				mu.Unlock()
 				if err != nil {
 					return err
 				}
@@ -227,9 +225,7 @@ func resourceScalewayServerCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	mu.Lock()
 	server, err := scaleway.CreateServer(req)
-	mu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -329,9 +325,7 @@ func resourceScalewayServerUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	mu.Lock()
 	err := scaleway.PatchServer(d.Id(), req)
-	mu.Unlock()
 
 	if err != nil {
 		return fmt.Errorf("Failed patching scaleway server: %q", err)

--- a/scaleway/resource_server_test.go
+++ b/scaleway/resource_server_test.go
@@ -79,6 +79,13 @@ func TestAccScalewayServer_Basic(t *testing.T) {
 					testAccCheckScalewayServerIPDetachmentAttributes("scaleway_server.base"),
 				),
 			},
+			resource.TestStep{
+				Config: testAccCheckScalewayServerConfig_dataSource,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "state", "running"),
+				),
+			},
 		},
 	})
 }
@@ -325,6 +332,20 @@ func testAccCheckScalewayServerExists(n string) resource.TestCheckFunc {
 
 var armImageIdentifier = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
 var x86_64ImageIdentifier = "e20532c4-1fa0-4c97-992f-436b8d372c07"
+
+var testAccCheckScalewayServerConfig_dataSource = `
+data "scaleway_image" "ubuntu" {
+  architecture = "arm"
+  name         = "Ubuntu Xenial"
+}
+
+resource "scaleway_server" "base" {
+  name = "test"
+
+  image = "${data.scaleway_image.ubuntu.id}"
+  type = "C1"
+  tags = [ "terraform-test" ]
+}`
 
 var testAccCheckScalewayServerConfig = fmt.Sprintf(`
 resource "scaleway_server" "base" {

--- a/scaleway/resource_server_test.go
+++ b/scaleway/resource_server_test.go
@@ -344,7 +344,7 @@ resource "scaleway_server" "base" {
 
   image = "${data.scaleway_image.ubuntu.id}"
   type = "C1"
-  tags = [ "terraform-test" ]
+  tags = [ "terraform-test", "xenial" ]
 }`
 
 var testAccCheckScalewayServerConfig = fmt.Sprintf(`
@@ -362,7 +362,7 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "VC1S"
-  tags = [ "terraform-test" ]
+  tags = [ "terraform-test", "local_boot" ]
   boot_type = "local"
 }`, x86_64ImageIdentifier)
 
@@ -374,7 +374,7 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  tags = [ "terraform-test" ]
+  tags = [ "terraform-test", "scaleway_ip" ]
   public_ip = "${scaleway_ip.base.ip}"
 }`, armImageIdentifier)
 
@@ -393,7 +393,7 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  tags = [ "terraform-test" ]
+  tags = [ "terraform-test", "inline-images" ]
 
   volume {
     size_in_gb = 20
@@ -427,7 +427,7 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  tags = [ "terraform-test" ]
+  tags = [ "terraform-test", "security_groups.blue" ]
   security_group = "${scaleway_security_group.blue.id}"
 }`, armImageIdentifier)
 
@@ -447,6 +447,6 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
-  tags = [ "terraform-test" ]
+  tags = [ "terraform-test", "security_groups.red" ]
   security_group = "${scaleway_security_group.red.id}"
 }`, armImageIdentifier)

--- a/scaleway/resource_ssh_key.go
+++ b/scaleway/resource_ssh_key.go
@@ -40,8 +40,6 @@ func getSSHKeyFingerprint(key []byte) (string, error) {
 func resourceScalewaySSHKeyCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
 	fingerprint, err := getSSHKeyFingerprint([]byte(d.Get("key").(string)))
 	if err != nil {
 		return err
@@ -106,9 +104,6 @@ func resourceScalewaySSHKeyRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceScalewaySSHKeyDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	user, err := scaleway.GetUser()
 	if err != nil {

--- a/scaleway/resource_token.go
+++ b/scaleway/resource_token.go
@@ -56,7 +56,6 @@ func resourceScalewayToken() *schema.Resource {
 func resourceScalewayTokenCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
 	email := ""
 	if mail, ok := d.GetOk("email"); ok {
 		email = mail.(string)
@@ -73,7 +72,6 @@ func resourceScalewayTokenCreate(d *schema.ResourceData, m interface{}) error {
 		Password: d.Get("password").(string),
 		Expires:  d.Get("expires").(bool),
 	})
-	mu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -113,9 +111,6 @@ func resourceScalewayTokenRead(d *schema.ResourceData, m interface{}) error {
 func resourceScalewayTokenUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	if d.HasChange("description") || d.HasChange("expires") {
 		_, err := scaleway.UpdateToken(&api.UpdateTokenRequest{
 			ID:          d.Id(),
@@ -132,9 +127,6 @@ func resourceScalewayTokenUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScalewayTokenDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err := scaleway.DeleteToken(d.Id())
 	if err != nil {

--- a/scaleway/resource_user_data.go
+++ b/scaleway/resource_user_data.go
@@ -43,7 +43,6 @@ func resourceScalewayUserData() *schema.Resource {
 func resourceScalewayUserDataCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
 	if err := scaleway.PatchUserdata(
 		d.Get("server").(string),
 		d.Get("key").(string),
@@ -51,7 +50,6 @@ func resourceScalewayUserDataCreate(d *schema.ResourceData, m interface{}) error
 		false); err != nil {
 		return err
 	}
-	mu.Unlock()
 
 	d.SetId(fmt.Sprintf("userdata-%s-%s", d.Get("server").(string), d.Get("key").(string)))
 	return resourceScalewayUserDataRead(d, m)
@@ -89,7 +87,6 @@ func resourceScalewayUserDataRead(d *schema.ResourceData, m interface{}) error {
 func resourceScalewayUserDataUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
 	if err := scaleway.PatchUserdata(
 		d.Get("server").(string),
 		d.Get("key").(string),
@@ -97,16 +94,12 @@ func resourceScalewayUserDataUpdate(d *schema.ResourceData, m interface{}) error
 		false); err != nil {
 		return err
 	}
-	mu.Unlock()
 
 	return resourceScalewayUserDataRead(d, m)
 }
 
 func resourceScalewayUserDataDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err := scaleway.DeleteUserdata(
 		d.Get("server").(string),

--- a/scaleway/resource_user_data_test.go
+++ b/scaleway/resource_user_data_test.go
@@ -70,6 +70,8 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
+
+  tags = [ "terraform-test", "user-data" ]
 }
 
 resource "scaleway_user_data" "base" {

--- a/scaleway/resource_volume.go
+++ b/scaleway/resource_volume.go
@@ -56,9 +56,6 @@ func resourceScalewayVolume() *schema.Resource {
 func resourceScalewayVolumeCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	size := uint64(d.Get("size_in_gb").(int)) * gb
 	req := api.VolumeDefinition{
 		Name:         d.Get("name").(string),
@@ -102,9 +99,6 @@ func resourceScalewayVolumeRead(d *schema.ResourceData, m interface{}) error {
 func resourceScalewayVolumeUpdate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	var req api.VolumePutDefinition
 	if d.HasChange("name") {
 		req.Name = String(d.Get("name").(string))
@@ -121,9 +115,6 @@ func resourceScalewayVolumeUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScalewayVolumeDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err := scaleway.DeleteVolume(d.Id())
 	if err != nil {

--- a/scaleway/resource_volume_attachment.go
+++ b/scaleway/resource_volume_attachment.go
@@ -37,9 +37,7 @@ var errVolumeAlreadyAttached = fmt.Errorf("Scaleway volume already attached")
 func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 
-	mu.Lock()
 	vol, err := scaleway.GetVolume(d.Get("volume").(string))
-	mu.Unlock()
 
 	if err != nil {
 		return err
@@ -74,9 +72,7 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 			var req = api.ServerPatchDefinition{
 				Volumes: &volumes,
 			}
-			mu.Lock()
 			err := scaleway.PatchServer(server.Identifier, req)
-			mu.Unlock()
 
 			if err == nil {
 				return nil
@@ -170,9 +166,7 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 			var req = api.ServerPatchDefinition{
 				Volumes: &volumes,
 			}
-			mu.Lock()
 			err := scaleway.PatchServer(server.Identifier, req)
-			mu.Unlock()
 
 			if err == nil {
 				return nil

--- a/scaleway/resource_volume_attachment_test.go
+++ b/scaleway/resource_volume_attachment_test.go
@@ -77,6 +77,8 @@ resource "scaleway_server" "base" {
   # ubuntu 14.04
   image = "%s"
   type = "C1"
+
+  tags = [ "terraform-test", "external-volume-attachment" ]
 }
 
 resource "scaleway_volume" "test" {


### PR DESCRIPTION
As reported in #83 recreation of servers due to image id changes does not work.
I've checked and it seems that the task API introduced in #55 stopped returning correct data - e.g. long after the server is shutdown the task is still in `pending` state.

So this change effectively reverts the change from #55 while also removing most of the mutexes placed around the provider.
There's also been a new testcase to ensure that there's no regression moving forward.

All tests are green (together with #86):

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (9.80s)
=== RUN   TestAccScalewayDataSourceImage_Basic
--- PASS: TestAccScalewayDataSourceImage_Basic (24.92s)
=== RUN   TestAccScalewayDataSourceImage_Filtered
--- PASS: TestAccScalewayDataSourceImage_Filtered (23.04s)
=== RUN   TestAccScalewaySecurityGroupDataSource_Basic
--- PASS: TestAccScalewaySecurityGroupDataSource_Basic (14.17s)
=== RUN   TestAccScalewayDataSourceVolume_Basic
--- PASS: TestAccScalewayDataSourceVolume_Basic (12.13s)
=== RUN   TestAccScalewayIP_importBasic
--- PASS: TestAccScalewayIP_importBasic (8.47s)
=== RUN   TestAccScalewaySecurityGroup_importBasic
--- PASS: TestAccScalewaySecurityGroup_importBasic (8.45s)
=== RUN   TestAccScalewayServer_importBasic
--- PASS: TestAccScalewayServer_importBasic (80.53s)
=== RUN   TestAccScalewayToken_importBasic
--- PASS: TestAccScalewayToken_importBasic (22.79s)
=== RUN   TestAccScalewayUserData_importBasic
--- PASS: TestAccScalewayUserData_importBasic (100.06s)
=== RUN   TestAccScalewayVolume_importBasic
--- PASS: TestAccScalewayVolume_importBasic (7.86s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccScalewayIP_Count
--- PASS: TestAccScalewayIP_Count (13.14s)
=== RUN   TestAccScalewayIP_Basic
--- PASS: TestAccScalewayIP_Basic (128.85s)
=== RUN   TestAccScalewaySecurityGroupRule_Basic
--- PASS: TestAccScalewaySecurityGroupRule_Basic (18.78s)
=== RUN   TestAccScalewaySecurityGroupRule_Count
--- PASS: TestAccScalewaySecurityGroupRule_Count (18.80s)
=== RUN   TestAccScalewaySecurityGroup_Basic
--- PASS: TestAccScalewaySecurityGroup_Basic (10.49s)
=== RUN   TestAccScalewayServer_Basic
--- PASS: TestAccScalewayServer_Basic (239.57s)
=== RUN   TestAccScalewayServer_BootType
--- PASS: TestAccScalewayServer_BootType (67.89s)
=== RUN   TestAccScalewayServer_ExistingIP
--- PASS: TestAccScalewayServer_ExistingIP (104.61s)
=== RUN   TestAccScalewayServer_Volumes
--- PASS: TestAccScalewayServer_Volumes (108.64s)
=== RUN   TestAccScalewayServer_SecurityGroup
--- PASS: TestAccScalewayServer_SecurityGroup (104.55s)
=== RUN   TestGetSSHKeyFingerprint
--- PASS: TestGetSSHKeyFingerprint (0.00s)
=== RUN   TestAccScalewaySSHKey_Basic
--- PASS: TestAccScalewaySSHKey_Basic (35.92s)
=== RUN   TestAccScalewayToken_Basic
--- PASS: TestAccScalewayToken_Basic (35.22s)
=== RUN   TestAccScalewayToken_Expiry
--- PASS: TestAccScalewayToken_Expiry (19.28s)
=== RUN   TestAccScalewayUserData_Basic
--- PASS: TestAccScalewayUserData_Basic (100.39s)
=== RUN   TestAccScalewayVolumeAttachment_Basic
--- PASS: TestAccScalewayVolumeAttachment_Basic (312.07s)
=== RUN   TestAccScalewayVolume_Basic
--- PASS: TestAccScalewayVolume_Basic (9.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	1639.632s
```