### PR TITLE
fix token import/ subsequent read

### DIFF
--- a/scaleway/resource_token.go
+++ b/scaleway/resource_token.go
@@ -93,6 +93,9 @@ func resourceScalewayTokenCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(token.ID)
+	// the secret_key is not present in read operations
+	d.Set("secret_key", token.SecretKey)
+
 	return resourceScalewayTokenUpdate(d, m)
 }
 
@@ -115,7 +118,10 @@ func resourceScalewayTokenRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("user_id", token.UserID)
 	d.Set("creation_ip", token.CreationIP)
 	d.Set("access_key", token.AccessKey)
-	d.Set("secret_key", token.SecretKey)
+	// this is compatibilty to old tokens: the secret key is the id
+	if d.Get("secret_key") == "" {
+		d.Set("secret_key", token.ID)
+	}
 	user, err := scaleway.GetUser()
 	if err != nil {
 		return err


### PR DESCRIPTION
the `secret_key` is not present in subsequent read operations, so we set
it after creation and fallback to the old semantics of using the ID if
it's not set.

we'll probably need to support a different way if important a token in
the future.