### PR TITLE
provider/scaleway: add scaleway_bucket resource

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"scaleway_bucket":              resourceScalewayBucket(),
 			"scaleway_user_data":           resourceScalewayUserData(),
 			"scaleway_server":              resourceScalewayServer(),
 			"scaleway_token":               resourceScalewayToken(),

--- a/scaleway/resource_bucket.go
+++ b/scaleway/resource_bucket.go
@@ -1,0 +1,69 @@
+package scaleway
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	api "github.com/nicolai86/scaleway-sdk"
+)
+
+func resourceScalewayBucket() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceScalewayBucketCreate,
+		Read:   resourceScalewayBucketRead,
+		Delete: resourceScalewayBucketDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the bucket",
+			},
+		},
+	}
+}
+
+func resourceScalewayBucketRead(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	_, err := scaleway.ListObjects(d.Get("name").(string))
+	if err != nil {
+		if serr, ok := err.(api.APIError); ok && serr.StatusCode == 404 {
+			log.Printf("[DEBUG] Bucket %q was not found - removing from state!", d.Get("name").(string))
+			d.SetId("")
+			return nil
+		}
+	}
+
+	return err
+}
+
+func resourceScalewayBucketCreate(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	container, err := scaleway.CreateBucket(&api.CreateBucketRequest{
+		Name:         d.Get("name").(string),
+		Organization: scaleway.Organization,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(container.Name)
+	return nil
+}
+
+func resourceScalewayBucketDelete(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	err := scaleway.DeleteBucket(d.Id())
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/scaleway/resource_bucket_test.go
+++ b/scaleway/resource_bucket_test.go
@@ -1,0 +1,80 @@
+package scaleway
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("scaleway_bucket", &resource.Sweeper{
+		Name: "scaleway_bucket",
+		F:    testSweepBucket,
+	})
+}
+
+func testSweepBucket(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	scaleway := client.(*Client).scaleway
+	log.Printf("[DEBUG] Destroying the buckets in (%s)", region)
+
+	containers, err := scaleway.GetContainers()
+	if err != nil {
+		return fmt.Errorf("Error describing buckets in Sweeper: %s", err)
+	}
+
+	for _, c := range containers {
+		if err := scaleway.DeleteBucket(c.Name); err != nil {
+			return fmt.Errorf("Error deleting bucket in Sweeper: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccScalewayBucket(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayBucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayBucket,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_bucket.base", "name", "terraform-test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayBucketDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client).scaleway
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "scaleway" {
+			continue
+		}
+
+		_, err := client.ListObjects(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Bucket still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccCheckScalewayBucket = `
+resource "scaleway_bucket" "base" {
+  name = "terraform-test"
+}
+`

--- a/website/docs/r/bucket.html.markdown
+++ b/website/docs/r/bucket.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: bucket"
+sidebar_current: "docs-scaleway-resource-bucket"
+description: |-
+  Manages Scaleway buckets.
+---
+
+# scaleway_bucket
+
+Creates Scaleway object storage buckets.
+
+## Example Usage
+
+```hcl
+resource "scaleway_bucket" "test" {
+  name = "sample-bucket"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the Scaleway objectstorage bucket
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - Name of the resource
+
+## Import
+
+Instances can be imported using the `name`, e.g.
+
+```
+$ terraform import scaleway_bucket.releases releases
+```

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -31,6 +31,9 @@
         <li<%= sidebar_current("docs-scaleway-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-scaleway-resource-bucket") %>>
+              <a href="/docs/providers/scaleway/r/bucket.html">scaleway_bucket</a>
+            </li>
             <li<%= sidebar_current("docs-scaleway-resource-ip") %>>
               <a href="/docs/providers/scaleway/r/ip.html">scaleway_ip</a>
             </li>


### PR DESCRIPTION
This PR adds a new resource to the Scaleway provider: `scaleway_bucket`.

This can be merged once Scaleway objectstorage is out of GA.

```
make testacc TESTARGS="-run='TestAccScalewayBucket'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccScalewayBucket' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-scaleway	[no test files]
=== RUN   TestAccScalewayBucket
--- PASS: TestAccScalewayBucket (13.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway
```

The PR includes docs, tests as well as the resource itself.