### PR TITLE
introduce new scaleway_ip_reverse_dns resource

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 			"scaleway_token":               resourceScalewayToken(),
 			"scaleway_ssh_key":             resourceScalewaySSHKey(),
 			"scaleway_ip":                  resourceScalewayIP(),
+			"scaleway_ip_reverse_dns":      resourceScalewayIPReverseDNS(),
 			"scaleway_security_group":      resourceScalewaySecurityGroup(),
 			"scaleway_security_group_rule": resourceScalewaySecurityGroupRule(),
 			"scaleway_volume":              resourceScalewayVolume(),

--- a/scaleway/resource_ip_reverse_dns.go
+++ b/scaleway/resource_ip_reverse_dns.go
@@ -1,0 +1,108 @@
+package scaleway
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/nicolai86/scaleway-sdk"
+)
+
+func resourceScalewayIPReverseDNS() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceScalewayIPReverseDNSCreate,
+		Read:   resourceScalewayIPReverseDNSRead,
+		Update: resourceScalewayIPReverseDNSUpdate,
+		Delete: resourceScalewayIPReverseDNSDelete,
+
+		Schema: map[string]*schema.Schema{
+			"ip": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ipv4 address of the ip, or IP ID",
+			},
+			"reverse": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ipv4 reverse dns",
+			},
+		},
+	}
+}
+
+func resourceScalewayIPReverseDNSCreate(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	ips, err := scaleway.GetIPS()
+	if err != nil {
+		return err
+	}
+
+	pk := d.Get("ip").(string)
+	for _, ip := range ips {
+		if ip.ID == pk {
+			d.SetId(fmt.Sprintf("ip-reverse-dns/%s", ip.ID))
+			return resourceScalewayIPReverseDNSUpdate(d, m)
+		}
+	}
+
+	return fmt.Errorf("Unable to find IP with Address/ID %q", pk)
+}
+
+func resourceScalewayIPReverseDNSRead(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	ip, err := scaleway.GetIP(d.Get("ip").(string))
+	if err != nil {
+		if serr, ok := err.(api.APIError); ok {
+			if serr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+	if ip.Reverse != nil {
+		d.Set("reverse", *ip.Reverse)
+	}
+	return nil
+}
+
+func resourceScalewayIPReverseDNSUpdate(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	ip, err := scaleway.UpdateIP(api.UpdateIPRequest{
+		ID:      d.Get("ip").(string),
+		Reverse: d.Get("reverse").(string),
+	})
+	if err != nil {
+		return err
+	}
+	if ip.Reverse != nil {
+		d.Set("reverse", *ip.Reverse)
+	} else {
+		d.Set("reverse", "")
+	}
+
+	return resourceScalewayIPReverseDNSRead(d, m)
+}
+
+func resourceScalewayIPReverseDNSDelete(d *schema.ResourceData, m interface{}) error {
+	scaleway := m.(*Client).scaleway
+
+	_, err := scaleway.UpdateIP(api.UpdateIPRequest{
+		ID:      d.Get("ip").(string),
+		Reverse: "",
+	})
+	if err != nil {
+		if serr, ok := err.(api.APIError); ok {
+			if serr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+	d.SetId("")
+	return nil
+}

--- a/scaleway/resource_ip_reverse_dns_test.go
+++ b/scaleway/resource_ip_reverse_dns_test.go
@@ -1,0 +1,42 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccScalewayIPReverseDNS_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayIPReverseDNSConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIPExists("scaleway_ip.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_ip_reverse_dns.google", "reverse", "www.google.com"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckScalewayIPReverseDNSConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIPExists("scaleway_ip.base"),
+					resource.TestCheckResourceAttr(
+						"scaleway_ip.base", "reverse", "www.google.com"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckScalewayIPReverseDNSConfig = `
+resource "scaleway_ip" "base" {}
+
+resource "scaleway_ip_reverse_dns" "google" {
+	ip = "${scaleway_ip.base.id}"
+	reverse = "www.google.com"
+}
+`

--- a/website/docs/r/ip.html.markdown
+++ b/website/docs/r/ip.html.markdown
@@ -22,7 +22,7 @@ resource "scaleway_ip" "test_ip" {}
 The following arguments are supported:
 
 * `server` - (Optional) ID of server to associate IP with
-* `reverse` - (Optional) Reverse DNS of the IP
+* `reverse` - (Deprecated) Please us the scaleway_ip_reverse_dns resource instead.
 
 ## Attributes Reference
 

--- a/website/docs/r/ip_reverse_dns.html.markdown
+++ b/website/docs/r/ip_reverse_dns.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: ip_reverse_dns"
+sidebar_current: "docs-scaleway-resource-ip-reverse-dns"
+description: |-
+  Manages Scaleway IPs.
+---
+
+# scaleway_ip_reverse_dns
+
+Provides reverse DNS settings for IPs.
+For additional details please refer to [API documentation](https://developer.scaleway.com/#ips).
+
+## Example Usage
+
+```hcl
+resource "scaleway_ip" "test_service" {}
+
+resource "scaleway_ip_reverse_dns" "google" {
+  ip = "${scaleway_ip.test_service.id}"
+  reverse = "test_service.awesome-corp.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ip` - (Required) ID or Address of IP 
+* `reverse` - (Required) Reverse DNS of the IP
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the new resource
+* `reverse` - reverse DNS setting of the IP resource


### PR DESCRIPTION
some usecases like dynamic reverse dns result in circular dependencies
between `scaleway_ip` and `scaleway_server` resources.

To break this cycle the `reverse` attribute on `scaleway_ip` is going to
be deprecated, and instead a new `scaleway_ip_reverse_dns` resource is
made available, which allows the IP to be created before the reverse DNS
is persisted.

Tests for the new resource as well as old modified resource are green.

Once merged this will fix use cases like https://github.com/terraform-providers/terraform-provider-scaleway/issues/88