### PR TITLE
add stateful security gorups and cloudinit for servers

### DIFF
--- a/scaleway/resource_security_group.go
+++ b/scaleway/resource_security_group.go
@@ -5,8 +5,11 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	api "github.com/nicolai86/scaleway-sdk"
 )
+
+var supportedDefaultTrafficPolicies = []string{"accept", "drop"}
 
 func resourceScalewaySecurityGroup() *schema.Resource {
 	return &schema.Resource{
@@ -29,6 +32,25 @@ func resourceScalewaySecurityGroup() *schema.Resource {
 				Required:    true,
 				Description: "The description of the security group",
 			},
+			"stateful": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Mark security group as stateful",
+			},
+			"inbound_default_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "Default inbound traffic policy for this security group",
+				ValidateFunc: validation.StringInSlice(supportedDefaultTrafficPolicies, true),
+			},
+			"outbound_default_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "Default outbound traffic policy for this security group",
+				ValidateFunc: validation.StringInSlice(supportedDefaultTrafficPolicies, true),
+			},
 			"enable_default_security": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -48,6 +70,9 @@ func resourceScalewaySecurityGroupCreate(d *schema.ResourceData, m interface{}) 
 		Description:           d.Get("description").(string),
 		Organization:          scaleway.Organization,
 		EnableDefaultSecurity: d.Get("enable_default_security").(bool),
+		Stateful:              d.Get("stateful").(bool),
+		InboundDefaultPolicy:  d.Get("inbound_default_policy").(string),
+		OutboundDefaultPolicy: d.Get("outbound_default_policy").(string),
 	}
 
 	group, err := scaleway.CreateSecurityGroup(req)
@@ -88,6 +113,9 @@ func resourceScalewaySecurityGroupRead(d *schema.ResourceData, m interface{}) er
 	d.Set("name", group.Name)
 	d.Set("description", group.Description)
 	d.Set("enable_default_security", group.EnableDefaultSecurity)
+	d.Set("stateful", group.Stateful)
+	d.Set("inbound_default_policy", group.InboundDefaultPolicy)
+	d.Set("outbound_default_policy", group.OutboundDefaultPolicy)
 
 	return nil
 }
@@ -96,9 +124,11 @@ func resourceScalewaySecurityGroupUpdate(d *schema.ResourceData, m interface{}) 
 	scaleway := m.(*Client).scaleway
 
 	var req = api.UpdateSecurityGroup{
-		Organization: scaleway.Organization,
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
+		Organization:          scaleway.Organization,
+		Name:                  d.Get("name").(string),
+		Description:           d.Get("description").(string),
+		InboundDefaultPolicy:  d.Get("inbound_default_policy").(string),
+		OutboundDefaultPolicy: d.Get("outbound_default_policy").(string),
 	}
 
 	if _, err := scaleway.UpdateSecurityGroup(req, d.Id()); err != nil {

--- a/scaleway/resource_security_group_test.go
+++ b/scaleway/resource_security_group_test.go
@@ -62,6 +62,34 @@ func TestAccScalewaySecurityGroup_Basic(t *testing.T) {
 	})
 }
 
+func TestAccScalewaySecurityGroup_Stateful(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewaySecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckScalewaySecurityGroupConfig_Stateful,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewaySecurityGroupExists("scaleway_security_group.base"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "inbound_default_policy", "accept"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "outbound_default_policy", "drop"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "stateful", "true"),
+				),
+			},
+			{
+				Config: testAccCheckScalewaySecurityGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewaySecurityGroupExists("scaleway_security_group.base"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "inbound_default_policy", "accept"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "outbound_default_policy", "drop"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "stateful", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckScalewaySecurityGroupDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*Client).scaleway
 
@@ -135,5 +163,15 @@ var testAccCheckScalewaySecurityGroupConfig = `
 resource "scaleway_security_group" "base" {
   name = "public"
   description = "public gateway"
+}
+`
+
+var testAccCheckScalewaySecurityGroupConfig_Stateful = `
+resource "scaleway_security_group" "base" {
+  name = "public"
+  description = "public gateway"
+  stateful = true 
+  inbound_default_policy = "accept"
+  outbound_default_policy = "drop"
 }
 `

--- a/scaleway/resource_server_test.go
+++ b/scaleway/resource_server_test.go
@@ -65,6 +65,8 @@ func TestAccScalewayServer_Basic(t *testing.T) {
 						"scaleway_server.base", "tags.0", "terraform-test"),
 					resource.TestCheckResourceAttr(
 						"scaleway_server.base", "boot_type", "bootscript"),
+					resource.TestCheckResourceAttr(
+						"scaleway_server.base", "cloudinit", "#cloud-config\napt_update: true\napt_upgrade: true\n"),
 				),
 			},
 			resource.TestStep{
@@ -354,6 +356,11 @@ resource "scaleway_server" "base" {
   image = "%s"
   type = "C1"
   tags = [ "terraform-test" ]
+  cloudinit = <<EOF
+#cloud-config
+apt_update: true
+apt_upgrade: true
+EOF
 }`, armImageIdentifier)
 
 var testAccCheckScalewayServerConfig_LocalBoot = fmt.Sprintf(`

--- a/vendor/github.com/nicolai86/scaleway-sdk/security_group.go
+++ b/vendor/github.com/nicolai86/scaleway-sdk/security_group.go
@@ -16,6 +16,9 @@ type SecurityGroup struct {
 	Servers               []ServerRef `json:"servers"`
 	EnableDefaultSecurity bool        `json:"enable_default_security"`
 	OrganizationDefault   bool        `json:"organization_default"`
+	Stateful              bool        `json:"stateful"`
+	InboundDefaultPolicy  string      `json:"inbound_default_policy"`  //accept, drop
+	OutboundDefaultPolicy string      `json:"outbound_default_policy"` //accept, drop
 }
 
 type SecurityGroupRef struct {
@@ -44,14 +47,20 @@ type NewSecurityGroup struct {
 	Name                  string `json:"name"`
 	Description           string `json:"description"`
 	EnableDefaultSecurity bool   `json:"enable_default_security"`
+	Stateful              bool   `json:"stateful"`
+	InboundDefaultPolicy  string `json:"inbound_default_policy"`
+	OutboundDefaultPolicy string `json:"outbound_default_policy"`
 }
 
 // UpdateSecurityGroup definition PUT request /security_groups
 type UpdateSecurityGroup struct {
-	Organization        string `json:"organization"`
-	Name                string `json:"name"`
-	Description         string `json:"description"`
-	OrganizationDefault bool   `json:"organization_default"`
+	Organization          string `json:"organization"`
+	Name                  string `json:"name"`
+	Description           string `json:"description"`
+	OrganizationDefault   bool   `json:"organization_default"`
+	Stateful              bool   `json:"stateful"`
+	InboundDefaultPolicy  string `json:"inbound_default_policy"`
+	OutboundDefaultPolicy string `json:"outbound_default_policy"`
 }
 
 // DeleteSecurityGroup deletes a SecurityGroup

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -578,10 +578,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "ggjRamhpTj5/WO50Bs0uLibRp70=",
+			"checksumSHA1": "UqrBTQ1T8hsFIfNZHHIns0vw2xo=",
 			"path": "github.com/nicolai86/scaleway-sdk",
-			"revision": "d887655bdfbf5d49469a9b4a68b1fb413afc5cb8",
-			"revisionTime": "2018-09-12T05:56:06Z"
+			"revision": "b20018e944c4ca3b5bc433a03304d2c18c12aa77",
+			"revisionTime": "2018-10-24T20:27:15Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -18,6 +18,9 @@ resource "scaleway_security_group" "test" {
   name                    = "test"
   description             = "test"
   enable_default_security = true
+  stateful                = true
+  inbound_default_policy  = "accept"
+  outbound_default_policy = "drop"
 }
 ```
 
@@ -28,6 +31,9 @@ The following arguments are supported:
 * `name` - (Required) name of security group
 * `description` - (Required) description of security group
 * `enable_default_security` - (Optional) default: true. Add default security group rules
+* `stateful` - (Optional) default: false. Mark the security group as stateful. Note that stateful security groups can not be associated with bare metal servers
+* `inbound_default_policy` - (Optional) default policy for inbound traffic. Can be one of accept or drop
+* `outbound_default_policy` - (Optional) default policy for outbound traffic. Can be one of accept or drop
 
 Field `name`, `description` are editable.
 

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `volume` - (Optional) attach additional volumes to your instance (see below)
 * `public_ipv6` - (Read Only) if `enable_ipv6` is set this contains the ipv6 address of your instance
 * `state` - (Optional) allows you to define the desired state of your server. Valid values include (`stopped`, `running`)
+* `cloudinit` - (Optional) allows you to define cloudinit script for this server
 * `state_detail` - (Read Only) contains details from the scaleway API the state of your instance
 
 Field `name`, `type`, `tags`, `dynamic_ip_required`, `security_group` are editable.


### PR DESCRIPTION
this was recently announced for servers and security groups.

security groups can be stateful, and support default inbound and
outbound policies now:

```
resource "scaleway_security_group" "base" {
  name = "public"
  description = "public gateway"
  stateful = true 
  inbound_default_policy = "accept"
  outbound_default_policy = "drop"
}
```

for details, see the launch blog post:
https://www.scaleway.com/docs/how-to-activate-a-stateful-cloud-firewall/

also, servers now support for cloud-init using user-data.

```
resource "scaleway_server" "base" {
  name = "test"
  # ubuntu 14.04
  image = "%s"
  type = "C1"
  tags = [ "terraform-test" ]
  cloudinit = <<EOF
#cloud-config
apt_update: true
apt_upgrade: true
EOF
}
```

for details, see the launch blog post:
https://blog.online.net/2018/07/05/introducing-scaleway-cloud-init-support/

tests are still green for this change.
