### PR TITLE
fix tests

### DIFF
--- a/scaleway/data_source_bootscript_test.go
+++ b/scaleway/data_source_bootscript_test.go
@@ -49,6 +49,6 @@ func testAccCheckBootscriptID(n string) resource.TestCheckFunc {
 const testAccCheckScalewayBootscriptFilterConfig = `
 data "scaleway_bootscript" "debug" {
   architecture = "arm"
-  name_filter = "Rescue"
+  name_filter = "rescue"
 }
 `

--- a/scaleway/resource_ip_test.go
+++ b/scaleway/resource_ip_test.go
@@ -199,15 +199,21 @@ resource "scaleway_ip" "base" {
 }
 `
 
-var testAccCheckScalewayIPAttachConfig = fmt.Sprintf(`
+var testAccCheckScalewayIPAttachConfig = `
+data "scaleway_image" "ubuntu" {
+  architecture = "arm64"
+  name         = "Ubuntu Xenial"
+  most_recent  = true
+}
+
 resource "scaleway_server" "base" {
   name = "test"
-  # ubuntu 14.04
-  image = "%s"
-  type = "C1"
+
+  image = "${data.scaleway_image.ubuntu.id}"
+  type = "ARM64-2GB"
 }
 
 resource "scaleway_ip" "base" {
   server = "${scaleway_server.base.id}"
 }
-`, armImageIdentifier)
+`

--- a/scaleway/resource_security_group.go
+++ b/scaleway/resource_security_group.go
@@ -9,7 +9,7 @@ import (
 	api "github.com/nicolai86/scaleway-sdk"
 )
 
-var supportedDefaultTrafficPolicies = []string{"accept", "drop"}
+var supportedDefaultTrafficPolicies = []string{"accept", "drop", ""}
 
 func resourceScalewaySecurityGroup() *schema.Resource {
 	return &schema.Resource{
@@ -40,14 +40,14 @@ func resourceScalewaySecurityGroup() *schema.Resource {
 			"inbound_default_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
+				Default:      "accept",
 				Description:  "Default inbound traffic policy for this security group",
 				ValidateFunc: validation.StringInSlice(supportedDefaultTrafficPolicies, true),
 			},
 			"outbound_default_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
+				Default:      "accept",
 				Description:  "Default outbound traffic policy for this security group",
 				ValidateFunc: validation.StringInSlice(supportedDefaultTrafficPolicies, true),
 			},

--- a/scaleway/resource_security_group_test.go
+++ b/scaleway/resource_security_group_test.go
@@ -81,9 +81,9 @@ func TestAccScalewaySecurityGroup_Stateful(t *testing.T) {
 				Config: testAccCheckScalewaySecurityGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewaySecurityGroupExists("scaleway_security_group.base"),
-					resource.TestCheckResourceAttr("scaleway_security_group.base", "inbound_default_policy", "accept"),
-					resource.TestCheckResourceAttr("scaleway_security_group.base", "outbound_default_policy", "drop"),
 					resource.TestCheckResourceAttr("scaleway_security_group.base", "stateful", "false"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "inbound_default_policy", "accept"),
+					resource.TestCheckResourceAttr("scaleway_security_group.base", "outbound_default_policy", "accept"),
 				),
 			},
 		},
@@ -170,7 +170,7 @@ var testAccCheckScalewaySecurityGroupConfig_Stateful = `
 resource "scaleway_security_group" "base" {
   name = "public"
   description = "public gateway"
-  stateful = true 
+  stateful = true
   inbound_default_policy = "accept"
   outbound_default_policy = "drop"
 }

--- a/scaleway/resource_user_data_test.go
+++ b/scaleway/resource_user_data_test.go
@@ -64,12 +64,18 @@ func testAccCheckScalewayUserDataDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccCheckScalewayUserDataConfig = fmt.Sprintf(`
+var testAccCheckScalewayUserDataConfig = `
+data "scaleway_image" "ubuntu" {
+  architecture = "arm64"
+  name         = "Ubuntu Xenial"
+  most_recent  = true
+}
+
 resource "scaleway_server" "base" {
   name = "test"
-  # ubuntu 14.04
-  image = "%s"
-  type = "C1"
+
+  image = "${data.scaleway_image.ubuntu.id}"
+  type = "ARM64-2GB"
 
   tags = [ "terraform-test", "user-data" ]
 }
@@ -79,4 +85,4 @@ resource "scaleway_user_data" "base" {
 	key = "gcp_username"
 	value = "supersecret"
 }
-`, armImageIdentifier)
+`

--- a/scaleway/resource_volume_attachment_test.go
+++ b/scaleway/resource_volume_attachment_test.go
@@ -71,12 +71,16 @@ func testAccCheckScalewayVolumeAttachmentExists(n string) resource.TestCheckFunc
 	}
 }
 
-var testAccCheckScalewayVolumeAttachmentConfig = fmt.Sprintf(`
+var testAccCheckScalewayVolumeAttachmentConfig = `
+data "scaleway_image" "ubuntu" {
+  name         = "Ubuntu Xenial"
+  architecture = "x86_64"
+}
+
 resource "scaleway_server" "base" {
   name = "test"
-  # ubuntu 14.04
-  image = "%s"
-  type = "C1"
+  image = "${data.scaleway_image.ubuntu.id}"
+  type = "C2S"
 
   tags = [ "terraform-test", "external-volume-attachment" ]
 }
@@ -90,4 +94,4 @@ resource "scaleway_volume" "test" {
 resource "scaleway_volume_attachment" "test" {
   server = "${scaleway_server.base.id}"
   volume = "${scaleway_volume.test.id}"
-}`, armImageIdentifier)
+}`


### PR DESCRIPTION
as far as I can see we have a bunch of failing tests right now: 

- [x] TestAccScalewayDataSourceBootscript_Filtered
- [x] TestAccScalewayServer_importBasic 
- [x] TestAccScalewayUserData_importBasic 
- [x] TestAccScalewayIP_Basic 
- [x] TestAccScalewaySecurityGroup_Stateful 
- [x] TestAccScalewayServer_Basic 
- [x] TestAccScalewayServer_BootType 
- [x] TestAccScalewayServer_ExistingIP 
- [x] TestAccScalewayServer_Volumes 
- [x] TestAccScalewayServer_SecurityGroup 
- [x] TestAccScalewayUserData_Basic 
- [x] TestAccScalewayVolumeAttachment_Basic 

these fail for various reasons, e.g. hardcoded IDs no longer being valid.

This PR brings all tests into a green state again.
This blocks the v1.8.0 release, which is important for the reverse dns deprecation...