### PR TITLE
Fix bullets and formatting in docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,9 +15,9 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 Here is an example that will setup the following:
-+ A Server.
-+ An IP Address.
-+ A security group.
+* A Server.
+* An IP Address.
+* A security group.
 
 (create this as sl.tf and run terraform commands from this directory):
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,7 +19,7 @@ Here is an example that will setup the following:
 * An IP Address.
 * A security group.
 
-(create this as sl.tf and run terraform commands from this directory):
+(create this as `sl.tf` and run terraform commands from this directory):
 
 ```hcl
 provider "scaleway" {
@@ -109,7 +109,7 @@ provider "scaleway" {
 
 ## Volume usage
 
-You can add volumes to baremetal instances.
+You can add volumes to bare metal instances.
 The minimal size of increment is 50GB and you can add at most 15 different volumes on an instance.
 
 Additional volumes cannot be added to virtual cloud servers.


### PR DESCRIPTION
These are just a few small changes in the docs to fix bullets so they render properly and a few formatting fixes.

Currently it shows the `+` instead of as a bulleted list. 
![image](https://user-images.githubusercontent.com/17609145/51125165-08df0680-17ee-11e9-9047-9b0c8fb04304.png)
