### PR TITLE
Ignore leading and trailing whitespaces when adding public SSH key

### DIFF
--- a/scaleway/resource_ssh_key.go
+++ b/scaleway/resource_ssh_key.go
@@ -67,7 +67,7 @@ func resourceScalewaySSHKeyCreate(d *schema.ResourceData, m interface{}) error {
 
 	user, err = scaleway.PatchUserSSHKey(user.ID, api.UserPatchSSHKeyDefinition{
 		SSHPublicKeys: append(keys, api.KeyDefinition{
-			Key: d.Get("key").(string),
+			Key: strings.TrimSpace(d.Get("key").(string)),
 		}),
 	})
 


### PR DESCRIPTION
Hello,

A small change to avoid using `trimspace()` Terraform function when adding keys generated by `ssh-keygen` and by Terraform TLS provider. Both generate keys with trailing newline character, which makes them to be rejected by Scaleway API. For details see https://community.scaleway.com/t/proposal-ssh-key-add-api-trim-spaces-on-server-side/7376