### PR TITLE
Return the env org value instead of the key

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -31,7 +31,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.SchemaDefaultFunc(func() (interface{}, error) {
 					for _, k := range []string{"SCALEWAY_TOKEN", "SCALEWAY_ACCESS_KEY"} {
 						if os.Getenv(k) != "" {
-							return k, nil
+							return os.Getenv(k), nil
 						}
 					}
 					if path, err := homedir.Expand("~/.scwrc"); err == nil {


### PR DESCRIPTION
Hey, instead of returning the `SCALEWAY_ORGANIZATION` env value, the key is returned.

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>