### PR TITLE
provider: Source SCALEWAY_ORGANIZATION variable correctly

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -51,7 +51,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.SchemaDefaultFunc(func() (interface{}, error) {
 					for _, k := range []string{"SCALEWAY_ORGANIZATION"} {
 						if os.Getenv(k) != "" {
-							return k, nil
+							return os.Getenv(k), nil
 						}
 					}
 					if path, err := homedir.Expand("~/.scwrc"); err == nil {


### PR DESCRIPTION
Similar to https://github.com/terraform-providers/terraform-provider-scaleway/pull/113 this fixes another bug introduced in https://github.com/terraform-providers/terraform-provider-scaleway/pull/111

Without this patch (and #113 ), the provider unfortunately can't authenticate against the API via ENV variables, which can also be seen by running any acceptance test:

```
=== RUN   TestAccScalewayBucket
--- FAIL: TestAccScalewayBucket (5.27s)
    testing.go:538: Step 0 error: Error applying: 1 error(s) occurred:
        
        * scaleway_bucket.base: 1 error(s) occurred:
        
        * scaleway_bucket.base: StatusCode: 400, Type: invalid_request_error, APIMessage:  [31mValidation Error [0m, Details: map[organization:[SCALEWAY_ORGANIZATION is not a valid UUID.]]
FAIL
```