### PR TITLE
provider: Enable request/response logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/hashicorp/go-retryablehttp v0.5.1
 	github.com/hashicorp/terraform v0.11.12-beta1.0.20190227065421-fc531f54a878
+	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
 	github.com/nicolai86/scaleway-sdk v0.0.0-20181024210327-b20018e944c4
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	golang.org/x/crypto v0.0.0-20180211211603-9de5f2eaf759

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,6 +101,7 @@ github.com/hashicorp/hil/scanner
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.11.12-beta1.0.20190227065421-fc531f54a878
 github.com/hashicorp/terraform/plugin
+github.com/hashicorp/terraform/helper/logging
 github.com/hashicorp/terraform/helper/resource
 github.com/hashicorp/terraform/helper/schema
 github.com/hashicorp/terraform/helper/validation
@@ -108,7 +109,6 @@ github.com/hashicorp/terraform/terraform
 github.com/hashicorp/terraform/plugin/discovery
 github.com/hashicorp/terraform/config/module
 github.com/hashicorp/terraform/helper/config
-github.com/hashicorp/terraform/helper/logging
 github.com/hashicorp/terraform/config
 github.com/hashicorp/terraform/config/configschema
 github.com/hashicorp/terraform/helper/hashcode


### PR DESCRIPTION
This is to enable logging of all requests and responses which go through the SDK (in `>=DEBUG` mode) to make debugging easier. This also helped in #114

## Example

```
---[ REQUEST ]---------------------------------------
POST /containers HTTP/1.1
Host: sis-ams1.scaleway.com
User-Agent: scaleway-sdk
Content-Length: 65
Content-Type: application/json
X-Auth-Token: <redacted>
Accept-Encoding: gzip

{
 "name": "terraform-test",
 "organization": "SCALEWAY_ORGANIZATION"
}

-----------------------------------------------------
2019/03/22 20:42:22 [DEBUG] Scaleway API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 BAD REQUEST
Connection: close
Content-Length: 140
Content-Type: application/json
Date: Fri, 22 Mar 2019 20:42:22 GMT
Server: Tengine

{
 "fields": {
  "organization": [
   "SCALEWAY_ORGANIZATION is not a valid UUID."
  ]
 },
 "message": "Validation Error",
 "type": "invalid_request_error"
}
-----------------------------------------------------
```