### PR TITLE
fix/scaleway_server: ignore state_detail in import

### DIFF
--- a/scaleway/import_server_test.go
+++ b/scaleway/import_server_test.go
@@ -22,6 +22,9 @@ func TestAccScalewayServer_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"state_detail",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
this changes if the server being imported is booting, so we can safely
ignore it§