### PR TITLE
fix data src tests to more recent ubuntu

### DIFF
--- a/scaleway/data_source_image_test.go
+++ b/scaleway/data_source_image_test.go
@@ -90,14 +90,14 @@ func testAccCheckImageID(n string) resource.TestCheckFunc {
 
 const testAccCheckScalewayImageConfig = `
 data "scaleway_image" "ubuntu" {
-  name = "Ubuntu Precise"
+  name = "Ubuntu Bionic"
   architecture = "arm"
 }
 `
 
 const testAccCheckScalewayImageConfig_mostRecent = `
 data "scaleway_image" "ubuntu" {
-  name = "Ubuntu Xenial"
+  name = "Ubuntu Bionic"
   architecture = "arm"
   most_recent = true
 }


### PR DESCRIPTION
Fixes data source tests due to old images:

```
------- Stdout: -------
=== RUN   TestAccScalewayDataSourceImage_Basic
--- FAIL: TestAccScalewayDataSourceImage_Basic (7.97s)
    testing.go:538: Step 0 error: Error refreshing: 1 error(s) occurred:
        
        * data.scaleway_image.ubuntu: 1 error(s) occurred:
        
        * data.scaleway_image.ubuntu: data.scaleway_image.ubuntu: The query returned no result. Please refine your query.
FAIL
```