### PR TITLE
doc: deprecate scaleway_token

### DIFF
--- a/scaleway/resource_token.go
+++ b/scaleway/resource_token.go
@@ -7,6 +7,8 @@ import (
 
 func resourceScalewayToken() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will be removed in the next major version",
+
 		Create: resourceScalewayTokenCreate,
 		Read:   resourceScalewayTokenRead,
 		Update: resourceScalewayTokenUpdate,

--- a/website/docs/r/token.html.markdown
+++ b/website/docs/r/token.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # scaleway_token
 
+**DEPRECATED**: This resource is deprecated and will be removed in `v2.0+`.
+
 Provides Tokens for scaleway API access. For additional details please refer to [API documentation](https://developer.scaleway.com/#tokens-tokens-post).
 
 ## Example Usage


### PR DESCRIPTION
Related to #143 

For security reasons, we estimate that users should not create tokens with terraform.