### PR TITLE
doc: deprecate scaleway_ssh_key

### DIFF
--- a/scaleway/resource_ssh_key.go
+++ b/scaleway/resource_ssh_key.go
@@ -11,6 +11,8 @@ import (
 
 func resourceScalewaySSHKey() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will be removed in the next major version",
+
 		Create: resourceScalewaySSHKeyCreate,
 		Read:   resourceScalewaySSHKeyRead,
 		Delete: resourceScalewaySSHKeyDelete,

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # scaleway_ssh_key
 
+**DEPRECATED**: This resource is deprecated and will be removed in `v2.0+`.
+
 Manages user SSH Keys to access servers provisioned on scaleway.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#users-user-get).
 


### PR DESCRIPTION
Related to #143

For security reasons, we estimate that users should not manage ssh keys with terraform.