### PR TITLE
doc: deprecate scaleway_bucket

### DIFF
--- a/scaleway/resource_bucket.go
+++ b/scaleway/resource_bucket.go
@@ -10,6 +10,10 @@ import (
 
 func resourceScalewayBucket() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: `This resource is deprecated and will be removed in the next major version.
+
+Please use scaleway_storage_object_bucket instead.`,
+
 		Create: resourceScalewayBucketCreate,
 		Read:   resourceScalewayBucketRead,
 		Delete: resourceScalewayBucketDelete,

--- a/website/docs/r/bucket.html.markdown
+++ b/website/docs/r/bucket.html.markdown
@@ -8,6 +8,9 @@ description: |-
 
 # scaleway_bucket
 
+**DEPRECATED**: This resource is deprecated and will be removed in `v2.0+`.
+Please use `scaleway_storage_object_bucket` instead.
+
 Creates Scaleway object storage buckets.
 
 ## Example Usage


### PR DESCRIPTION
Related to #143

This resource is deprecated and will be removed in the next major version.
Please use scaleway_storage_object_bucket instead.