### PR TITLE
doc: remove deprecated sidebar_current

### DIFF
--- a/website/docs/d/bootscript.html.markdown
+++ b/website/docs/d/bootscript.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: scaleway_bootscript"
-sidebar_current: "docs-scaleway-datasource-bootscript"
 description: |-
   Get information on a Scaleway bootscript.
 ---

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: scaleway_image"
-sidebar_current: "docs-scaleway-datasource-image"
 description: |-
   Get information on a Scaleway image.
 ---

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: scaleway_security_group"
-sidebar_current: "docs-scaleway-datasource-security-group"
 description: |-
   Gets information about a Security Group.
 ---

--- a/website/docs/d/volume.html.markdown
+++ b/website/docs/d/volume.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: scaleway_volume"
-sidebar_current: "docs-scaleway-datasource-volume"
 description: |-
   Gets information about a Volume.
 ---

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Provider: Scaleway"
-sidebar_current: "docs-scaleway-index"
 description: |-
   The Scaleway provider is used to interact with Scaleway bare metal & VPS provider.
 ---

--- a/website/docs/r/bucket.html.markdown
+++ b/website/docs/r/bucket.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: bucket"
-sidebar_current: "docs-scaleway-resource-bucket"
 description: |-
   Manages Scaleway buckets.
 ---

--- a/website/docs/r/compute_instance_ip.html.markdown
+++ b/website/docs/r/compute_instance_ip.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: scaleway_compute_instance_ip"
-sidebar_current: "docs-scaleway-resource-compute-instance-ip"
 description: |-
   Manages Scaleway Compute Instance IPs.
 ---

--- a/website/docs/r/ip.html.markdown
+++ b/website/docs/r/ip.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: ip"
-sidebar_current: "docs-scaleway-resource-ip"
 description: |-
   Manages Scaleway IPs.
 ---

--- a/website/docs/r/ip_reverse_dns.html.markdown
+++ b/website/docs/r/ip_reverse_dns.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: ip_reverse_dns"
-sidebar_current: "docs-scaleway-resource-ip-reverse-dns"
 description: |-
   Manages Scaleway IPs.
 ---

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: security_group"
-sidebar_current: "docs-scaleway-resource-security-group-x"
 description: |-
   Manages Scaleway security groups.
 ---

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: security_group_rule"
-sidebar_current: "docs-scaleway-resource-security-group-rule"
 description: |-
   Manages Scaleway security group rules.
 ---

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: server"
-sidebar_current: "docs-scaleway-resource-server"
 description: |-
   Manages Scaleway servers.
 ---

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: ssh_key"
-sidebar_current: "docs-scaleway-resource-ssh_key"
 description: |-
   Manages Scaleway user SSH keys.
 ---

--- a/website/docs/r/token.html.markdown
+++ b/website/docs/r/token.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: token"
-sidebar_current: "docs-scaleway-resource-token"
 description: |-
   Manages Scaleway Tokens.
 ---

--- a/website/docs/r/user_data.html.markdown
+++ b/website/docs/r/user_data.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: user_data"
-sidebar_current: "docs-scaleway-resource-user-data"
 description: |-
   Manages Scaleway Server UserData.
 ---

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: volume"
-sidebar_current: "docs-scaleway-resource-volume-x"
 description: |-
   Manages Scaleway Volumes.
 ---

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "scaleway"
 page_title: "Scaleway: volume attachment"
-sidebar_current: "docs-scaleway-resource-volume-attachment"
 description: |-
   Manages Scaleway Volume attachments for servers.
 ---

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -2,63 +2,62 @@
   <% content_for :sidebar do %>
     <div class="docs-sidebar hidden-print affix-top" role="complementary">
       <ul class="nav docs-sidenav">
-        <li<%= sidebar_current("docs-home") %>>
+        <li>
           <a href="/docs/providers/index.html">All Providers</a>
         </li>
 
-        <li<%= sidebar_current("docs-scaleway-index") %>>
+        <li>
           <a href="/docs/providers/scaleway/index.html">Scaleway Provider</a>
         </li>
 
-        <li<%= sidebar_current("docs-scaleway-datasource") %>>
+        <li>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-scaleway-datasource-bootscript") %>>
+            <li>
               <a href="/docs/providers/scaleway/d/bootscript.html">scaleway_bootscript</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-datasource-image") %>>
+            <li>
               <a href="/docs/providers/scaleway/d/image.html">scaleway_image</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-datasource-security-group") %>>
+            <li>
               <a href="/docs/providers/scaleway/d/security_group.html">scaleway_security_group</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-datasource-volume") %>>
+            <li>
               <a href="/docs/providers/scaleway/d/volume.html">scaleway_volume</a>
             </li>
           </ul>
         </li>
 
-        <li<%= sidebar_current("docs-scaleway-resource") %>>
-          <a href="#">Deprecated Resources</a>
+        <li>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-scaleway-resource-bucket") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/bucket.html">scaleway_bucket</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-ip") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/ip.html">scaleway_ip</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-security-group") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/security_group.html">scaleway_security_group</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-security-group-rule") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/security_group_rule.html">scaleway_security_group_rule</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-server") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/server.html">scaleway_server</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-ssh-key") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/ssh_key.html">scaleway_ssh_key</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-token") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/token.html">scaleway_token</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-user-data") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/user_data.html">scaleway_user_data</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-volume-x") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/volume.html">scaleway_volume</a>
             </li>
-            <li<%= sidebar_current("docs-scaleway-resource-volume-attachment") %>>
+            <li>
               <a href="/docs/providers/scaleway/r/volume_attachment.html">scaleway_volume_attachment</a>
             </li>
           </ul>

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -29,8 +29,8 @@
         </li>
 
         <li>
+          <a href="#">Deprecated Resources</a>
           <ul class="nav nav-visible">
-            <a href="#">Deprecated Resources</a>
             <li>
               <a href="/docs/providers/scaleway/r/bucket.html">scaleway_bucket</a>
             </li>

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -30,6 +30,7 @@
 
         <li>
           <ul class="nav nav-visible">
+            <a href="#">Deprecated Resources</a>
             <li>
               <a href="/docs/providers/scaleway/r/bucket.html">scaleway_bucket</a>
             </li>


### PR DESCRIPTION
YAML frontmatter key `sidebar_current` and method `sidebar_current` are deprecated.

More info: https://github.com/hashicorp/terraform-website#yaml-frontmatter