### PR TITLE
fix: resource_compute_instance_server tests

### DIFF
--- a/scaleway/resource_compute_instance_server.go
+++ b/scaleway/resource_compute_instance_server.go
@@ -420,6 +420,8 @@ func resourceScalewayComputeInstanceServerUpdate(d *schema.ResourceData, m inter
 				Name: getRandomName("vol"), // name is ignored by the API, any name will work here
 			}
 		}
+
+		updateRequest.Volumes = &volumes
 	}
 
 	if d.HasChange("placement_group_id") {
@@ -429,10 +431,6 @@ func resourceScalewayComputeInstanceServerUpdate(d *schema.ResourceData, m inter
 		} else {
 			updateRequest.ComputeCluster = &instance.NullableStringValue{Value: placementGroupID}
 		}
-	}
-
-	if len(volumes) > 0 {
-		updateRequest.Volumes = &volumes
 	}
 
 	var updateResponse *instance.UpdateServerResponse

--- a/scaleway/resource_compute_instance_server.go
+++ b/scaleway/resource_compute_instance_server.go
@@ -413,13 +413,13 @@ func resourceScalewayComputeInstanceServerUpdate(d *schema.ResourceData, m inter
 
 	if raw, ok := d.GetOk("additional_volume_ids"); d.HasChange("additional_volume_ids") && ok {
 		volumes["0"] = &instance.VolumeTemplate{ID: d.Get("root_volume.0.volume_id").(string), Name: getRandomName("vol")} // name is ignored by the API, any name will work here
+
 		for i, volumeID := range raw.([]interface{}) {
 			volumes[strconv.Itoa(i+1)] = &instance.VolumeTemplate{
 				ID:   expandID(volumeID),
 				Name: getRandomName("vol"), // name is ignored by the API, any name will work here
 			}
 		}
-
 	}
 
 	if d.HasChange("placement_group_id") {
@@ -431,7 +431,9 @@ func resourceScalewayComputeInstanceServerUpdate(d *schema.ResourceData, m inter
 		}
 	}
 
-	updateRequest.Volumes = &volumes
+	if len(volumes) > 0 {
+		updateRequest.Volumes = &volumes
+	}
 
 	var updateResponse *instance.UpdateServerResponse
 

--- a/scaleway/resource_compute_instance_server_test.go
+++ b/scaleway/resource_compute_instance_server_test.go
@@ -45,7 +45,7 @@ func TestAccScalewayComputeInstanceServerRootVolume1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayComputeInstanceServerExists("scaleway_compute_instance_server.base"),
 					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "root_volume.0.delete_on_termination", "true"),
-					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "root_volume.0.size_in_gb", "50"),
+					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "root_volume.0.size_in_gb", "60"),
 					resource.TestCheckResourceAttrSet("scaleway_compute_instance_server.base", "root_volume.0.volume_id"),
 					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "tags.2", "root_volume"),
 				),

--- a/scaleway/resource_compute_instance_server_test.go
+++ b/scaleway/resource_compute_instance_server_test.go
@@ -45,7 +45,7 @@ func TestAccScalewayComputeInstanceServerRootVolume1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayComputeInstanceServerExists("scaleway_compute_instance_server.base"),
 					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "root_volume.0.delete_on_termination", "true"),
-					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "root_volume.0.size_in_gb", "60"),
+					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "root_volume.0.size_in_gb", "50"),
 					resource.TestCheckResourceAttrSet("scaleway_compute_instance_server.base", "root_volume.0.volume_id"),
 					resource.TestCheckResourceAttr("scaleway_compute_instance_server.base", "tags.2", "root_volume"),
 				),


### PR DESCRIPTION
Before:
```bash
$ grep "FAIL:" ~/Desktop/tf-test-TestAccScalewayComputeInstanceServer.log
--- FAIL: TestAccScalewayComputeInstanceServerRemoteExec (3.99s)
--- FAIL: TestAccScalewayComputeInstanceServerRootVolume1 (97.62s)
```

After:
```bash
$ grep "FAIL:" ~/Desktop/tf-test-TestAccScalewayComputeInstanceServer-without-fix.log
--- FAIL: TestAccScalewayComputeInstanceServerAdditionalVolumes2 (4.34s)
--- FAIL: TestAccScalewayComputeInstanceServerState2 (45.51s)
--- FAIL: TestAccScalewayComputeInstanceServerRemoteExec (2.52s)
--- FAIL: TestAccScalewayComputeInstanceServerRootVolume1 (100.82s)
--- FAIL: TestAccScalewayComputeInstanceServerState1 (123.24s)
--- FAIL: TestAccScalewayComputeInstanceServerUserData1 (132.82s)
--- FAIL: TestAccScalewayComputeInstanceServerUserData2 (138.27s)
```