### PR TITLE
Update and rename account_ssk_key.html.markdown to account_ssh_key.html

### DIFF
--- a/website/docs/r/account_ssh_key.html.markdown
+++ b/website/docs/r/account_ssh_key.html.markdown
@@ -1,11 +1,11 @@
 ---
 layout: "scaleway"
-page_title: "Scaleway: scaleway_account_ssk_key"
+page_title: "Scaleway: scaleway_account_ssh_key"
 description: |-
   Manages Scaleway user SSH keys.
 ---
 
-# scaleway_account_ssk_key
+# scaleway_account_ssh_key
 
 Manages user SSH keys to access servers provisioned on Scaleway.
 

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -26,7 +26,7 @@
           <a href="#">Account Resources</a>
           <ul class="nav nav-visible">
             <li>
-              <a href="/docs/providers/scaleway/r/account_ssk_key.html">account_ssk_key</a>
+              <a href="/docs/providers/scaleway/r/account_ssh_key.html">account_ssh_key</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This is a quick typo fix for the documentation.