### PR TITLE
break: rename disable_public_ip to disable_dynamic_ip

### DIFF
--- a/scaleway/resource_instance_server.go
+++ b/scaleway/resource_instance_server.go
@@ -128,7 +128,7 @@ func resourceScalewayInstanceServer() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Disable dynamic ip on the server",
+				Description: "Disable dynamic IP on the server",
 			},
 			"state": {
 				Type:        schema.TypeString,
@@ -172,6 +172,14 @@ func resourceScalewayInstanceServer() *schema.Resource {
 			},
 			"zone":            zoneSchema(),
 			"organization_id": organizationIDSchema(),
+
+			// Deprecated and removed.
+			"disable_public_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Removed:  "Please use disable_dynamic_ip instead",
+			},
 		},
 	}
 }

--- a/scaleway/resource_instance_server.go
+++ b/scaleway/resource_instance_server.go
@@ -124,7 +124,7 @@ func resourceScalewayInstanceServer() *schema.Resource {
 				Computed:    true,
 				Description: "The public IPv4 address of the server",
 			},
-			"disable_public_ip": {
+			"disable_dynamic_ip": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -214,7 +214,7 @@ func resourceScalewayInstanceServerCreate(d *schema.ResourceData, m interface{})
 		CommercialType:    commercialType,
 		EnableIPv6:        d.Get("enable_ipv6").(bool),
 		SecurityGroup:     expandID(d.Get("security_group_id")),
-		DynamicIPRequired: Bool(!d.Get("disable_public_ip").(bool)),
+		DynamicIPRequired: Bool(!d.Get("disable_dynamic_ip").(bool)),
 	}
 
 	if placementGroupID, ok := d.GetOk("placement_group_id"); ok {
@@ -324,7 +324,7 @@ func resourceScalewayInstanceServerRead(d *schema.ResourceData, m interface{}) e
 	d.Set("tags", response.Server.Tags)
 	d.Set("security_group_id", response.Server.SecurityGroup.ID)
 	d.Set("enable_ipv6", response.Server.EnableIPv6)
-	d.Set("disable_public_ip", !response.Server.DynamicIPRequired)
+	d.Set("disable_dynamic_ip", !response.Server.DynamicIPRequired)
 
 	// TODO: If image is a label, check that response.Server.Image.ID match the label.
 	// It could be useful if the user edit the image with another tool.
@@ -443,8 +443,8 @@ func resourceScalewayInstanceServerUpdate(d *schema.ResourceData, m interface{})
 		updateRequest.EnableIPv6 = scw.BoolPtr(d.Get("enable_ipv6").(bool))
 	}
 
-	if d.HasChange("disable_public_ip") {
-		updateRequest.DynamicIPRequired = scw.BoolPtr(!d.Get("disable_public_ip").(bool))
+	if d.HasChange("disable_dynamic_ip") {
+		updateRequest.DynamicIPRequired = scw.BoolPtr(!d.Get("disable_dynamic_ip").(bool))
 	}
 
 	volumes := map[string]*instance.VolumeTemplate{}

--- a/scaleway/resource_instance_server_test.go
+++ b/scaleway/resource_instance_server_test.go
@@ -25,7 +25,7 @@ func TestAccScalewayInstanceServerMinimal1(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_instance_server.base", "root_volume.0.delete_on_termination", "true"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.base", "root_volume.0.size_in_gb", "20"),
 					resource.TestCheckResourceAttrSet("scaleway_instance_server.base", "root_volume.0.volume_id"),
-					resource.TestCheckResourceAttr("scaleway_instance_server.base", "disable_public_ip", "false"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.base", "disable_dynamic_ip", "false"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.base", "tags.0", "terraform-test"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.base", "tags.1", "scaleway_instance_server"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.base", "tags.2", "minimal"),

--- a/website/docs/r/instance_server.html.markdown
+++ b/website/docs/r/instance_server.html.markdown
@@ -146,7 +146,7 @@ attached to the server. Updates to this field will trigger a stop/start of the s
 
 - `enable_ipv6` - (Defaults to `false`) Determines if IPv6 is enabled for the server.
 
-- `disable_dynamic_ip` - (Defaults to `false`) Disable dynamic ip on the server.
+- `disable_dynamic_ip` - (Defaults to `false`) Disable dynamic IP on the server.
 
 - `state` - (Defaults to `started`) The state of the server. Possible values are: `started`, `stopped` or `standby`.
 

--- a/website/docs/r/instance_server.html.markdown
+++ b/website/docs/r/instance_server.html.markdown
@@ -146,6 +146,8 @@ attached to the server. Updates to this field will trigger a stop/start of the s
 
 - `enable_ipv6` - (Defaults to `false`) Determines if IPv6 is enabled for the server.
 
+- `disable_dynamic_ip` - (Defaults to `false`) Disable dynamic ip on the server.
+
 - `state` - (Defaults to `started`) The state of the server. Possible values are: `started`, `stopped` or `standby`.
 
 - `cloud_init` - (Optional) The cloud init script associated with this server. Updates to this field will trigger a stop/start of the server.


### PR DESCRIPTION
This PR is a **BREAKING CHANGE** and:
- Remove the misnamed attribute `disable_public_ip` (with a "Please use disable_dynamic_ip instead" message)
- Replace it with a `disable_dynamic_ip` attribute
- Document the `disable_dynamic_ip` attribute