### PR TITLE
fix(ssh_key): Trim ssh key before sending it to the API

### DIFF
--- a/scaleway/resource_account_ssh_key.go
+++ b/scaleway/resource_account_ssh_key.go
@@ -1,6 +1,8 @@
 package scaleway
 
 import (
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	account "github.com/scaleway/scaleway-sdk-go/api/account/v2alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -26,6 +28,10 @@ func resourceScalewayAccountSSKKey() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: "The public SSH key",
+				// We dont consider trailing \n as diff
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+				},
 			},
 			"organization_id": organizationIDSchema(),
 		},
@@ -37,7 +43,7 @@ func resourceScalewayAccountSSHKeyCreate(d *schema.ResourceData, m interface{}) 
 
 	res, err := accountAPI.CreateSSHKey(&account.CreateSSHKeyRequest{
 		Name:           d.Get("name").(string),
-		PublicKey:      d.Get("public_key").(string),
+		PublicKey:      strings.Trim(d.Get("public_key").(string), "\n"),
 		OrganizationID: d.Get("organization_id").(string),
 	})
 	if err != nil {

--- a/scaleway/resource_account_ssh_key.go
+++ b/scaleway/resource_account_ssh_key.go
@@ -28,7 +28,7 @@ func resourceScalewayAccountSSKKey() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: "The public SSH key",
-				// We dont consider trailing \n as diff
+				// We don't consider trailing \n as diff
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.Trim(old, "\n") == strings.Trim(new, "\n")
 				},

--- a/scaleway/resource_account_ssh_key_test.go
+++ b/scaleway/resource_account_ssh_key_test.go
@@ -16,7 +16,12 @@ func TestAccScalewayAccountSSHKey(t *testing.T) {
 		CheckDestroy: testAccCheckScalewayAccountSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScalewayAccountSSHKeyConfig[0],
+				Config: fmt.Sprintf(`
+					resource "scaleway_account_ssh_key" "main" {
+						name 	   = "main"
+						public_key = "%s"
+					}
+				`, accountSSHKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayAccountSSHKeyExists("scaleway_account_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "name", "main"),
@@ -24,10 +29,38 @@ func TestAccScalewayAccountSSHKey(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccScalewayAccountSSHKeyConfig[1],
+				Config: fmt.Sprintf(`
+					resource "scaleway_account_ssh_key" "main" {
+						name 	   = "main-updated"
+						public_key = "%s"
+					}
+				`, accountSSHKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayAccountSSHKeyExists("scaleway_account_ssh_key.main"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "name", "main-updated"),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", accountSSHKey),
+				),
+			},
+		},
+	})
+}
+
+func TestAccScalewayAccountSSHKey_WithNewLine(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayAccountSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "scaleway_account_ssh_key" "main" {
+						name 	   = "main"
+						public_key = "\n\n%s\n\n"
+					}
+				`, accountSSHKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayAccountSSHKeyExists("scaleway_account_ssh_key.main"),
+					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "name", "main"),
 					resource.TestCheckResourceAttr("scaleway_account_ssh_key.main", "public_key", accountSSHKey),
 				),
 			},
@@ -82,18 +115,3 @@ func testAccCheckScalewayAccountSSHKeyExists(n string) resource.TestCheckFunc {
 }
 
 const accountSSHKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC7P977mH29VxAEHy+rzuZjYzcMKdx2fYlQvg+9EXnhzadFY2tqimOy0GBMMN263KwATHcJ7tqnKS8ahg3mdWJjKZyBFIeWozCggxJGNbWDjpw5qiSvnPQjfeqRYZedS5vi/rAPZpGZVyXGeLUd01QEKhnMGUdBiLtaAg1UgBeDYQ== opensource@scaleway.com"
-
-var testAccScalewayAccountSSHKeyConfig = []string{
-	fmt.Sprintf(`
-		resource "scaleway_account_ssh_key" "main" {
-			name 	   = "main"
-			public_key = "%s"
-		}
-	`, accountSSHKey),
-	fmt.Sprintf(`
-		resource "scaleway_account_ssh_key" "main" {
-			name 	   = "main-updated"
-			public_key = "%s"
-		}
-	`, accountSSHKey),
-}


### PR DESCRIPTION
fix #302 