### PR TITLE
chore: remove deprecated call to terraform.VersionString()

### DIFF
--- a/scaleway/config.go
+++ b/scaleway/config.go
@@ -31,6 +31,7 @@ type Meta struct {
 	DefaultOrganizationID string
 	DefaultRegion         scw.Region
 	DefaultZone           scw.Zone
+	TerraformVersion      string
 
 	// scwClient is the Scaleway SDK client.
 	scwClient *scw.Client
@@ -66,7 +67,7 @@ func (m *Meta) bootstrap() error {
 func (m *Meta) bootstrapScwClient() error {
 	options := []scw.ClientOption{
 		scw.WithHTTPClient(createRetryableHTTPClient(false)),
-		scw.WithUserAgent(userAgent),
+		scw.WithUserAgent(fmt.Sprintf("terraform-provider/%s terraform/%s", version, m.TerraformVersion)),
 	}
 
 	// The access key is not used for API authentications.

--- a/scaleway/helpers.go
+++ b/scaleway/helpers.go
@@ -19,9 +19,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// userAgent used for SDK requests.
-var userAgent = fmt.Sprintf("terraform-provider/%s terraform/%s", version, terraform.VersionString())
-
 // Bool returns a pointer to of the bool value passed in.
 func Bool(val bool) *bool {
 	return &val

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -43,7 +43,7 @@ func Provider() terraform.ResourceProvider {
 	// load env
 	envProfile := scw.LoadEnvProfile()
 
-	return &schema.Provider{
+	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"access_key": {
 				Type:        schema.TypeString,
@@ -220,13 +220,23 @@ func Provider() terraform.ResourceProvider {
 			"scaleway_volume":          dataSourceScalewayVolume(),
 			"scaleway_account_ssh_key": dataSourceScalewayAccountSSHKey(),
 		},
-
-		ConfigureFunc: providerConfigure,
 	}
+
+	p.ConfigureFunc = func(data *schema.ResourceData) (i interface{}, e error) {
+		terraformVersion := p.TerraformVersion
+		if terraformVersion == "" {
+			// Terraform 0.12 introduced this field to the protocol
+			// We can therefore assume that if it's missing it's 0.10 or 0.11
+			terraformVersion = "0.11+compatible"
+		}
+		return providerConfigure(data, terraformVersion)
+	}
+
+	return p
 }
 
 // providerConfigure creates the Meta object containing the SDK client.
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
 	apiKey := ""
 	if v, ok := d.Get("secret_key").(string); ok {
 		apiKey = v
@@ -273,6 +283,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		DefaultOrganizationID: organizationID,
 		DefaultRegion:         region,
 		DefaultZone:           zone,
+		TerraformVersion:      terraformVersion,
 	}
 
 	meta.bootstrap()


### PR DESCRIPTION
Here example given in TF docs: https://github.com/terraform-providers/terraform-provider-kubernetes/pull/620/files