### PR TITLE
chore: remove unnecessary get prefixes from getters

### DIFF
--- a/scaleway/config.go
+++ b/scaleway/config.go
@@ -177,7 +177,7 @@ func (m *Meta) bootstrapS3Client() error {
 	config := &aws.Config{}
 	config.WithRegion(string(m.DefaultRegion))
 	config.WithCredentials(credentials.NewStaticCredentials(m.AccessKey, m.SecretKey, ""))
-	config.WithEndpoint(m.getS3Endpoint(m.DefaultRegion))
+	config.WithEndpoint(m.s3Endpoint(m.DefaultRegion))
 
 	s, err := session.NewSession(config)
 	if err != nil {
@@ -188,8 +188,8 @@ func (m *Meta) bootstrapS3Client() error {
 	return nil
 }
 
-// getS3Endpoint returns the correct S3 endpoint for object storage based on the current region
-func (m *Meta) getS3Endpoint(region scw.Region) string {
+// s3Endpoint returns the correct S3 endpoint for object storage based on the current region
+func (m *Meta) s3Endpoint(region scw.Region) string {
 	return "https://s3." + string(region) + ".scw.cloud"
 
 }

--- a/scaleway/data_source_account_ssh_key.go
+++ b/scaleway/data_source_account_ssh_key.go
@@ -36,7 +36,7 @@ func dataSourceScalewayAccountSSHKey() *schema.Resource {
 }
 
 func dataSourceScalewayAccountSSHKeyRead(d *schema.ResourceData, m interface{}) error {
-	accountAPI := getAccountAPI(m)
+	accountAPI := accountAPI(m)
 
 	var sshKey *account.SSHKey
 	sshKeyID, ok := d.GetOk("ssh_key_id")

--- a/scaleway/data_source_baremetal_offer_beta.go
+++ b/scaleway/data_source_baremetal_offer_beta.go
@@ -131,7 +131,7 @@ func dataSourceScalewayBaremetalOfferBeta() *schema.Resource {
 
 func dataSourceScalewayBaremetalOfferBetaRead(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
-	baremetalApi, fallBackZone, err := getBaremetalAPIWithZone(d, meta)
+	baremetalApi, fallBackZone, err := baremetalAPIWithZone(d, meta)
 	if err != nil {
 		return err
 	}

--- a/scaleway/data_source_instance_image.go
+++ b/scaleway/data_source_instance_image.go
@@ -92,7 +92,7 @@ func dataSourceScalewayInstanceImage() *schema.Resource {
 
 func dataSourceScalewayInstanceImageRead(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
-	instanceApi, zone, err := getInstanceAPIWithZone(d, meta)
+	instanceApi, zone, err := instanceAPIWithZone(d, meta)
 	if err != nil {
 		return err
 	}

--- a/scaleway/data_source_instance_security_group.go
+++ b/scaleway/data_source_instance_security_group.go
@@ -33,7 +33,7 @@ func dataSourceScalewayInstanceSecurityGroup() *schema.Resource {
 
 func dataSourceScalewayInstanceSecurityGroupRead(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
-	instanceApi, zone, err := getInstanceAPIWithZone(d, meta)
+	instanceApi, zone, err := instanceAPIWithZone(d, meta)
 	if err != nil {
 		return err
 	}

--- a/scaleway/data_source_instance_server.go
+++ b/scaleway/data_source_instance_server.go
@@ -32,7 +32,7 @@ func dataSourceScalewayInstanceServer() *schema.Resource {
 
 func dataSourceScalewayInstanceServerRead(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
-	instanceApi, zone, err := getInstanceAPIWithZone(d, meta)
+	instanceApi, zone, err := instanceAPIWithZone(d, meta)
 	if err != nil {
 		return err
 	}

--- a/scaleway/data_source_instance_volume.go
+++ b/scaleway/data_source_instance_volume.go
@@ -31,7 +31,7 @@ func dataSourceScalewayInstanceVolume() *schema.Resource {
 
 func dataSourceScalewayInstanceVolumeRead(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
-	instanceApi, zone, err := getInstanceAPIWithZone(d, meta)
+	instanceApi, zone, err := instanceAPIWithZone(d, meta)
 	if err != nil {
 		return err
 	}

--- a/scaleway/data_source_instance_volume_test.go
+++ b/scaleway/data_source_instance_volume_test.go
@@ -15,7 +15,7 @@ func TestAccScalewayDataSourceInstanceVolume_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_instance_volume" "test" {
-						name = "` + getRandomName("volume") + `"
+						name = "` + newRandomName("volume") + `"
 						size_in_gb = 2
 						type = "l_ssd"
 					}

--- a/scaleway/data_source_marketplace_image_beta.go
+++ b/scaleway/data_source_marketplace_image_beta.go
@@ -29,7 +29,7 @@ func dataSourceScalewayMarketplaceImageBeta() *schema.Resource {
 func dataSourceScalewayMarketplaceImageReadBeta(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
 	marketplaceAPI := marketplace.NewAPI(meta.scwClient)
-	zone, err := getZone(d, meta)
+	zone, err := extractZone(d, meta)
 	if err != nil {
 		return err
 	}

--- a/scaleway/helper_storage_object.go
+++ b/scaleway/helper_storage_object.go
@@ -6,11 +6,11 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-// getS3ClientWithRegion returns a new S3 client with the correct region extracted from the resource data.
-func getS3ClientWithRegion(d *schema.ResourceData, m interface{}) (*s3.S3, scw.Region, error) {
+// s3ClientWithRegion returns a new S3 client with the correct region extracted from the resource data.
+func s3ClientWithRegion(d *schema.ResourceData, m interface{}) (*s3.S3, scw.Region, error) {
 	meta := m.(*Meta)
 
-	region, err := getRegion(d, meta)
+	region, err := extractRegion(d, meta)
 	if err != nil {
 		return nil, "", err
 	}
@@ -31,8 +31,8 @@ func getS3ClientWithRegion(d *schema.ResourceData, m interface{}) (*s3.S3, scw.R
 	return meta.s3Client, region, err
 }
 
-// getS3ClientWithRegion returns a new S3 client with the correct region and name extracted from the resource data.
-func getS3ClientWithRegionAndName(m interface{}, name string) (*s3.S3, scw.Region, string, error) {
+// s3ClientWithRegion returns a new S3 client with the correct region and name extracted from the resource data.
+func s3ClientWithRegionAndName(m interface{}, name string) (*s3.S3, scw.Region, string, error) {
 	meta := m.(*Meta)
 
 	region, name, err := parseRegionalID(name)

--- a/scaleway/helpers_account.go
+++ b/scaleway/helpers_account.go
@@ -4,8 +4,8 @@ import (
 	account "github.com/scaleway/scaleway-sdk-go/api/account/v2alpha1"
 )
 
-// getAccountAPI returns a new account API.
-func getAccountAPI(m interface{}) *account.API {
+// accountAPI returns a new account API.
+func accountAPI(m interface{}) *account.API {
 	meta := m.(*Meta)
 
 	return account.NewAPI(meta.scwClient)

--- a/scaleway/helpers_baremetal.go
+++ b/scaleway/helpers_baremetal.go
@@ -17,17 +17,17 @@ const (
 
 var baremetalServerResourceTimeout = baremetalServerRetryFuncTimeout + time.Minute
 
-// getInstanceAPIWithZone returns a new baremetal API and the zone for a Create request
-func getBaremetalAPIWithZone(d *schema.ResourceData, m interface{}) (*baremetal.API, scw.Zone, error) {
+// instanceAPIWithZone returns a new baremetal API and the zone for a Create request
+func baremetalAPIWithZone(d *schema.ResourceData, m interface{}) (*baremetal.API, scw.Zone, error) {
 	meta := m.(*Meta)
 	baremetalAPI := baremetal.NewAPI(meta.scwClient)
 
-	zone, err := getZone(d, meta)
+	zone, err := extractZone(d, meta)
 	return baremetalAPI, zone, err
 }
 
-// getInstanceAPIWithZoneAndID returns an baremetal API with zone and ID extracted from the state
-func getBaremetalAPIWithZoneAndID(m interface{}, id string) (*baremetal.API, scw.Zone, string, error) {
+// instanceAPIWithZoneAndID returns an baremetal API with zone and ID extracted from the state
+func baremetalAPIWithZoneAndID(m interface{}, id string) (*baremetal.API, scw.Zone, string, error) {
 	meta := m.(*Meta)
 	baremetalAPI := baremetal.NewAPI(meta.scwClient)
 
@@ -36,8 +36,8 @@ func getBaremetalAPIWithZoneAndID(m interface{}, id string) (*baremetal.API, scw
 }
 
 // TODO: Remove it when SDK will handle it.
-// getBaremetalOfferByName call baremetal API to get an offer by its exact name.
-func getBaremetalOfferByName(baremetalAPI *baremetal.API, zone scw.Zone, offerName string) (*baremetal.Offer, error) {
+// baremetalOfferByName call baremetal API to get an offer by its exact name.
+func baremetalOfferByName(baremetalAPI *baremetal.API, zone scw.Zone, offerName string) (*baremetal.Offer, error) {
 	offerRes, err := baremetalAPI.ListOffers(&baremetal.ListOffersRequest{
 		Zone: zone,
 	}, scw.WithAllPages())
@@ -55,8 +55,8 @@ func getBaremetalOfferByName(baremetalAPI *baremetal.API, zone scw.Zone, offerNa
 }
 
 // TODO: Remove it when SDK will handle it.
-// getBaremetalOfferByID call baremetal API to get an offer by its exact name.
-func getBaremetalOfferByID(baremetalAPI *baremetal.API, zone scw.Zone, offerID string) (*baremetal.Offer, error) {
+// baremetalOfferByID call baremetal API to get an offer by its exact name.
+func baremetalOfferByID(baremetalAPI *baremetal.API, zone scw.Zone, offerID string) (*baremetal.Offer, error) {
 	offerRes, err := baremetalAPI.ListOffers(&baremetal.ListOffersRequest{
 		Zone: zone,
 	}, scw.WithAllPages())

--- a/scaleway/helpers_instance.go
+++ b/scaleway/helpers_instance.go
@@ -19,17 +19,17 @@ const (
 	InstanceServerWaitForTimeout = 10 * time.Minute
 )
 
-// getInstanceAPIWithZone returns a new instance API and the zone for a Create request
-func getInstanceAPIWithZone(d *schema.ResourceData, m interface{}) (*instance.API, scw.Zone, error) {
+// instanceAPIWithZone returns a new instance API and the zone for a Create request
+func instanceAPIWithZone(d *schema.ResourceData, m interface{}) (*instance.API, scw.Zone, error) {
 	meta := m.(*Meta)
 	instanceAPI := instance.NewAPI(meta.scwClient)
 
-	zone, err := getZone(d, meta)
+	zone, err := extractZone(d, meta)
 	return instanceAPI, zone, err
 }
 
-// getInstanceAPIWithZoneAndID returns an instance API with zone and ID extracted from the state
-func getInstanceAPIWithZoneAndID(m interface{}, id string) (*instance.API, scw.Zone, string, error) {
+// instanceAPIWithZoneAndID returns an instance API with zone and ID extracted from the state
+func instanceAPIWithZoneAndID(m interface{}, id string) (*instance.API, scw.Zone, string, error) {
 	meta := m.(*Meta)
 	instanceAPI := instance.NewAPI(meta.scwClient)
 

--- a/scaleway/helpers_k8s.go
+++ b/scaleway/helpers_k8s.go
@@ -39,16 +39,16 @@ const (
 	K8SClusterWaitForDeletedTimeout = 10 * time.Minute
 )
 
-func getK8SAPIWithRegion(d *schema.ResourceData, m interface{}) (*k8s.API, scw.Region, error) {
+func k8sAPIWithRegion(d *schema.ResourceData, m interface{}) (*k8s.API, scw.Region, error) {
 	meta := m.(*Meta)
 	k8sAPI := k8s.NewAPI(meta.scwClient)
 
-	region, err := getRegion(d, meta)
+	region, err := extractRegion(d, meta)
 
 	return k8sAPI, region, err
 }
 
-func getK8SAPIWithRegionAndID(m interface{}, id string) (*k8s.API, scw.Region, string, error) {
+func k8sAPIWithRegionAndID(m interface{}, id string) (*k8s.API, scw.Region, string, error) {
 	meta := m.(*Meta)
 	k8sAPI := k8s.NewAPI(meta.scwClient)
 

--- a/scaleway/helpers_lb.go
+++ b/scaleway/helpers_lb.go
@@ -12,23 +12,23 @@ const (
 	LbWaitForTimeout = 10 * time.Minute
 )
 
-// getLbAPI returns a new lb API
-func getLbAPI(m interface{}) *lb.API {
+// lbAPI returns a new lb API
+func lbAPI(m interface{}) *lb.API {
 	meta := m.(*Meta)
 	return lb.NewAPI(meta.scwClient)
 }
 
-// getLbAPIWithRegion returns a new lb API and the region for a Create request
-func getLbAPIWithRegion(d *schema.ResourceData, m interface{}) (*lb.API, scw.Region, error) {
+// lbAPIWithRegion returns a new lb API and the region for a Create request
+func lbAPIWithRegion(d *schema.ResourceData, m interface{}) (*lb.API, scw.Region, error) {
 	meta := m.(*Meta)
 	lbApi := lb.NewAPI(meta.scwClient)
 
-	region, err := getRegion(d, meta)
+	region, err := extractRegion(d, meta)
 	return lbApi, region, err
 }
 
-// getLbAPIWithRegionAndID returns an lb API with region and ID extracted from the state
-func getLbAPIWithRegionAndID(m interface{}, id string) (*lb.API, scw.Region, string, error) {
+// lbAPIWithRegionAndID returns an lb API with region and ID extracted from the state
+func lbAPIWithRegionAndID(m interface{}, id string) (*lb.API, scw.Region, string, error) {
 	meta := m.(*Meta)
 	lbApi := lb.NewAPI(meta.scwClient)
 

--- a/scaleway/helpers_rdb.go
+++ b/scaleway/helpers_rdb.go
@@ -12,23 +12,23 @@ const (
 	RdbWaitForTimeout = 10 * time.Minute
 )
 
-// getRdbAPI returns a new RDB API
-func getRdbAPI(m interface{}) *rdb.API {
+// rdbAPI returns a new RDB API
+func rdbAPI(m interface{}) *rdb.API {
 	meta := m.(*Meta)
 	return rdb.NewAPI(meta.scwClient)
 }
 
-// getRdbAPIWithRegion returns a new lb API and the region for a Create request
-func getRdbAPIWithRegion(d *schema.ResourceData, m interface{}) (*rdb.API, scw.Region, error) {
+// rdbAPIWithRegion returns a new lb API and the region for a Create request
+func rdbAPIWithRegion(d *schema.ResourceData, m interface{}) (*rdb.API, scw.Region, error) {
 	meta := m.(*Meta)
 	rdbApi := rdb.NewAPI(meta.scwClient)
 
-	region, err := getRegion(d, meta)
+	region, err := extractRegion(d, meta)
 	return rdbApi, region, err
 }
 
-// getRdbAPIWithRegionAndID returns an lb API with region and ID extracted from the state
-func getRdbAPIWithRegionAndID(m interface{}, id string) (*rdb.API, scw.Region, string, error) {
+// rdbAPIWithRegionAndID returns an lb API with region and ID extracted from the state
+func rdbAPIWithRegionAndID(m interface{}, id string) (*rdb.API, scw.Region, string, error) {
 	meta := m.(*Meta)
 	rdbApi := rdb.NewAPI(meta.scwClient)
 

--- a/scaleway/helpers_test.go
+++ b/scaleway/helpers_test.go
@@ -193,7 +193,7 @@ func TestIs403Error(t *testing.T) {
 }
 
 func TestGetRandomName(t *testing.T) {
-	name := getRandomName("test")
+	name := newRandomName("test")
 	assert.True(t, strings.HasPrefix(name, "tf-test-"))
 }
 

--- a/scaleway/resource_account_ssh_key.go
+++ b/scaleway/resource_account_ssh_key.go
@@ -39,7 +39,7 @@ func resourceScalewayAccountSSKKey() *schema.Resource {
 }
 
 func resourceScalewayAccountSSHKeyCreate(d *schema.ResourceData, m interface{}) error {
-	accountAPI := getAccountAPI(m)
+	accountAPI := accountAPI(m)
 
 	res, err := accountAPI.CreateSSHKey(&account.CreateSSHKeyRequest{
 		Name:           d.Get("name").(string),
@@ -56,7 +56,7 @@ func resourceScalewayAccountSSHKeyCreate(d *schema.ResourceData, m interface{}) 
 }
 
 func resourceScalewayAccountSSHKeyRead(d *schema.ResourceData, m interface{}) error {
-	accountAPI := getAccountAPI(m)
+	accountAPI := accountAPI(m)
 
 	res, err := accountAPI.GetSSHKey(&account.GetSSHKeyRequest{
 		SSHKeyID: d.Id(),
@@ -77,7 +77,7 @@ func resourceScalewayAccountSSHKeyRead(d *schema.ResourceData, m interface{}) er
 }
 
 func resourceScalewayAccountSSHKeyUpdate(d *schema.ResourceData, m interface{}) error {
-	accountAPI := getAccountAPI(m)
+	accountAPI := accountAPI(m)
 
 	if d.HasChange("name") {
 		_, err := accountAPI.UpdateSSHKey(&account.UpdateSSHKeyRequest{
@@ -93,7 +93,7 @@ func resourceScalewayAccountSSHKeyUpdate(d *schema.ResourceData, m interface{}) 
 }
 
 func resourceScalewayAccountSSHKeyDelete(d *schema.ResourceData, m interface{}) error {
-	accountAPI := getAccountAPI(m)
+	accountAPI := accountAPI(m)
 
 	err := accountAPI.DeleteSSHKey(&account.DeleteSSHKeyRequest{
 		SSHKeyID: d.Id(),

--- a/scaleway/resource_account_ssh_key_test.go
+++ b/scaleway/resource_account_ssh_key_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccScalewayAccountSSHKey(t *testing.T) {
-	name := getRandomName("ssh-key")
+	name := newRandomName("ssh-key")
 	SSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEEYrzDOZmhItdKaDAEqJQ4ORS2GyBMtBozYsK5kiXXX opensource@scaleway.com"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,7 +49,7 @@ func TestAccScalewayAccountSSHKey(t *testing.T) {
 }
 
 func TestAccScalewayAccountSSHKey_WithNewLine(t *testing.T) {
-	name := getRandomName("ssh-key")
+	name := newRandomName("ssh-key")
 	SSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDjfkdWCwkYlVQMDUfiZlVrmjaGOfBYnmkucssae8Iup opensource@scaleway.com"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -80,7 +80,7 @@ func testAccCheckScalewayAccountSSHKeyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		accountAPI := getAccountAPI(testAccProvider.Meta())
+		accountAPI := accountAPI(testAccProvider.Meta())
 
 		_, err := accountAPI.GetSSHKey(&account.GetSSHKeyRequest{
 			SSHKeyID: rs.Primary.ID,
@@ -107,7 +107,7 @@ func testAccCheckScalewayAccountSSHKeyExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		accountAPI := getAccountAPI(testAccProvider.Meta())
+		accountAPI := accountAPI(testAccProvider.Meta())
 
 		_, err := accountAPI.GetSSHKey(&account.GetSSHKeyRequest{
 			SSHKeyID: rs.Primary.ID,

--- a/scaleway/resource_baremetal_server_beta.go
+++ b/scaleway/resource_baremetal_server_beta.go
@@ -79,14 +79,14 @@ func resourceScalewayBaremetalServerBeta() *schema.Resource {
 }
 
 func resourceScalewayBaremetalServerBetaCreate(d *schema.ResourceData, m interface{}) error {
-	baremetalAPI, zone, err := getBaremetalAPIWithZone(d, m)
+	baremetalAPI, zone, err := baremetalAPIWithZone(d, m)
 	if err != nil {
 		return err
 	}
 
 	offer := d.Get("offer").(string)
 	if !sdkValidation.IsUUID(offer) {
-		o, err := getBaremetalOfferByName(baremetalAPI, zone, offer)
+		o, err := baremetalOfferByName(baremetalAPI, zone, offer)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func resourceScalewayBaremetalServerBetaCreate(d *schema.ResourceData, m interfa
 }
 
 func resourceScalewayBaremetalServerBetaRead(d *schema.ResourceData, m interface{}) error {
-	baremetalAPI, zone, ID, err := getBaremetalAPIWithZoneAndID(m, d.Id())
+	baremetalAPI, zone, ID, err := baremetalAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func resourceScalewayBaremetalServerBetaRead(d *schema.ResourceData, m interface
 		return err
 	}
 
-	offer, err := getBaremetalOfferByID(baremetalAPI, zone, res.OfferID)
+	offer, err := baremetalOfferByID(baremetalAPI, zone, res.OfferID)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func resourceScalewayBaremetalServerBetaRead(d *schema.ResourceData, m interface
 }
 
 func resourceScalewayBaremetalServerBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	baremetalAPI, zone, ID, err := getBaremetalAPIWithZoneAndID(m, d.Id())
+	baremetalAPI, zone, ID, err := baremetalAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func resourceScalewayBaremetalServerBetaUpdate(d *schema.ResourceData, m interfa
 }
 
 func resourceScalewayBaremetalServerBetaDelete(d *schema.ResourceData, m interface{}) error {
-	baremetalAPI, zone, ID, err := getBaremetalAPIWithZoneAndID(m, d.Id())
+	baremetalAPI, zone, ID, err := baremetalAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_baremetal_server_beta_test.go
+++ b/scaleway/resource_baremetal_server_beta_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestAccScalewayBaremetalServerBetaMinimal1(t *testing.T) {
-	SSHKeyName := getRandomName("ssh-key")
+	SSHKeyName := newRandomName("ssh-key")
 	SSHKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM7HUxRyQtB2rnlhQUcbDGCZcTJg7OvoznOiyC9W6IxH opensource@scaleway.com"
-	name := getRandomName("bm")
+	name := newRandomName("bm")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -153,7 +153,7 @@ func testAccCheckScalewayBaremetalServerBetaExists(n string) resource.TestCheckF
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		baremetalAPI, zone, ID, err := getBaremetalAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		baremetalAPI, zone, ID, err := baremetalAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ func testAccCheckScalewayBaremetalServerBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		baremetalAPI, zone, ID, err := getBaremetalAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		baremetalAPI, zone, ID, err := baremetalAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_instance_ip.go
+++ b/scaleway/resource_instance_ip.go
@@ -43,7 +43,7 @@ func resourceScalewayInstanceIP() *schema.Resource {
 }
 
 func resourceScalewayInstanceIPCreate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, err := getInstanceAPIWithZone(d, m)
+	instanceAPI, zone, err := instanceAPIWithZone(d, m)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func resourceScalewayInstanceIPCreate(d *schema.ResourceData, m interface{}) err
 }
 
 func resourceScalewayInstanceIPRead(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func resourceScalewayInstanceIPRead(d *schema.ResourceData, m interface{}) error
 }
 
 func resourceScalewayInstanceIPDelete(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_instance_ip_reverse_dns.go
+++ b/scaleway/resource_instance_ip_reverse_dns.go
@@ -32,7 +32,7 @@ func resourceScalewayInstanceIPReverseDns() *schema.Resource {
 }
 
 func resourceScalewayInstanceIPReverseDnsCreate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, err := getInstanceAPIWithZone(d, m)
+	instanceAPI, zone, err := instanceAPIWithZone(d, m)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func resourceScalewayInstanceIPReverseDnsCreate(d *schema.ResourceData, m interf
 }
 
 func resourceScalewayInstanceIPReverseDnsRead(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func resourceScalewayInstanceIPReverseDnsRead(d *schema.ResourceData, m interfac
 }
 
 func resourceScalewayInstanceIPReverseDnsUpdate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func resourceScalewayInstanceIPReverseDnsUpdate(d *schema.ResourceData, m interf
 }
 
 func resourceScalewayInstanceIPReverseDnsDelete(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_instance_ip_test.go
+++ b/scaleway/resource_instance_ip_test.go
@@ -66,7 +66,7 @@ func testAccCheckScalewayInstanceIPExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func testAccCheckScalewayInstanceIPPairWithServer(ipResource, serverResource str
 			return fmt.Errorf("resource not found: %s", serverResource)
 		}
 
-		instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), ipState.Primary.ID)
+		instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), ipState.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func testAccCheckScalewayInstanceServerNoIPAssigned(serverResource string) resou
 			return fmt.Errorf("resource not found: %s", serverResource)
 		}
 
-		instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), serverState.Primary.ID)
+		instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), serverState.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -158,7 +158,7 @@ func testAccCheckScalewayInstanceIPDestroy(s *terraform.State) error {
 			continue
 		}
 
-		instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_instance_placement_group.go
+++ b/scaleway/resource_instance_placement_group.go
@@ -55,7 +55,7 @@ func resourceScalewayInstancePlacementGroup() *schema.Resource {
 }
 
 func resourceScalewayInstancePlacementGroupCreate(d *schema.ResourceData, m interface{}) error {
-	instanceApi, zone, err := getInstanceAPIWithZone(d, m)
+	instanceApi, zone, err := instanceAPIWithZone(d, m)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func resourceScalewayInstancePlacementGroupCreate(d *schema.ResourceData, m inte
 }
 
 func resourceScalewayInstancePlacementGroupRead(d *schema.ResourceData, m interface{}) error {
-	instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceApi, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func resourceScalewayInstancePlacementGroupRead(d *schema.ResourceData, m interf
 }
 
 func resourceScalewayInstancePlacementGroupUpdate(d *schema.ResourceData, m interface{}) error {
-	instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceApi, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func resourceScalewayInstancePlacementGroupUpdate(d *schema.ResourceData, m inte
 }
 
 func resourceScalewayInstancePlacementGroupDelete(d *schema.ResourceData, m interface{}) error {
-	instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceApi, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_instance_placement_group_test.go
+++ b/scaleway/resource_instance_placement_group_test.go
@@ -50,7 +50,7 @@ func testAccCheckScalewayInstancePlacementGroupExists(n string) resource.TestChe
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceApi, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -74,7 +74,7 @@ func testAccCheckScalewayInstancePlacementGroupDestroy(s *terraform.State) error
 			continue
 		}
 
-		instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceApi, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_instance_security_group.go
+++ b/scaleway/resource_instance_security_group.go
@@ -72,12 +72,12 @@ func resourceScalewayInstanceSecurityGroup() *schema.Resource {
 
 func resourceScalewayInstanceSecurityGroupCreate(d *schema.ResourceData, m interface{}) error {
 	meta := m.(*Meta)
-	instanceApi, zone, err := getInstanceAPIWithZone(d, meta)
+	instanceApi, zone, err := instanceAPIWithZone(d, meta)
 	if err != nil {
 		return err
 	}
 
-	organizationID, err := getOrganizationID(d, meta)
+	organizationID, err := organizationID(d, meta)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func resourceScalewayInstanceSecurityGroupCreate(d *schema.ResourceData, m inter
 }
 
 func resourceScalewayInstanceSecurityGroupRead(d *schema.ResourceData, m interface{}) error {
-	instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceApi, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_instance_security_group_test.go
+++ b/scaleway/resource_instance_security_group_test.go
@@ -314,7 +314,7 @@ func testAccCheckScalewayInstanceSecurityGroupRuleIs(name string, direction inst
 			return fmt.Errorf("not found: %s", name)
 		}
 
-		instanceApi, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceApi, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_instance_server.go
+++ b/scaleway/resource_instance_server.go
@@ -214,7 +214,7 @@ func resourceScalewayInstanceServer() *schema.Resource {
 }
 
 func resourceScalewayInstanceServerCreate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, err := getInstanceAPIWithZone(d, m)
+	instanceAPI, zone, err := instanceAPIWithZone(d, m)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func resourceScalewayInstanceServerCreate(d *schema.ResourceData, m interface{})
 		for i, volumeID := range raw.([]interface{}) {
 			req.Volumes[strconv.Itoa(i+1)] = &instance.VolumeTemplate{
 				ID:   expandID(volumeID),
-				Name: getRandomName("vol"),
+				Name: newRandomName("vol"),
 			}
 		}
 	}
@@ -324,7 +324,7 @@ func resourceScalewayInstanceServerCreate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayInstanceServerRead(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -459,7 +459,7 @@ func resourceScalewayInstanceServerRead(d *schema.ResourceData, m interface{}) e
 }
 
 func resourceScalewayInstanceServerUpdate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -487,7 +487,7 @@ func resourceScalewayInstanceServerUpdate(d *schema.ResourceData, m interface{})
 	if d.HasChange("security_group_id") {
 		updateRequest.SecurityGroup = &instance.SecurityGroupTemplate{
 			ID:   expandID(d.Get("security_group_id")),
-			Name: getRandomName("sg"), // this value will be ignored by the API
+			Name: newRandomName("sg"), // this value will be ignored by the API
 		}
 	}
 
@@ -502,7 +502,7 @@ func resourceScalewayInstanceServerUpdate(d *schema.ResourceData, m interface{})
 	volumes := map[string]*instance.VolumeTemplate{}
 
 	if raw, ok := d.GetOk("additional_volume_ids"); d.HasChange("additional_volume_ids") && ok {
-		volumes["0"] = &instance.VolumeTemplate{ID: d.Get("root_volume.0.volume_id").(string), Name: getRandomName("vol")} // name is ignored by the API, any name will work here
+		volumes["0"] = &instance.VolumeTemplate{ID: d.Get("root_volume.0.volume_id").(string), Name: newRandomName("vol")} // name is ignored by the API, any name will work here
 
 		for i, volumeID := range raw.([]interface{}) {
 
@@ -513,7 +513,7 @@ func resourceScalewayInstanceServerUpdate(d *schema.ResourceData, m interface{})
 			}
 			volumes[strconv.Itoa(i+1)] = &instance.VolumeTemplate{
 				ID:   expandID(volumeID),
-				Name: getRandomName("vol"), // name is ignored by the API, any name will work here
+				Name: newRandomName("vol"), // name is ignored by the API, any name will work here
 			}
 		}
 
@@ -633,7 +633,7 @@ func resourceScalewayInstanceServerUpdate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayInstanceServerDelete(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_instance_server_test.go
+++ b/scaleway/resource_instance_server_test.go
@@ -539,7 +539,7 @@ func testAccCheckScalewayInstanceServerExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -559,7 +559,7 @@ func testAccCheckScalewayInstanceServerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		instanceAPI, zone, ID, err := getInstanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
+		instanceAPI, zone, ID, err := instanceAPIWithZoneAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_instance_volume.go
+++ b/scaleway/resource_instance_volume.go
@@ -72,7 +72,7 @@ func resourceScalewayInstanceVolume() *schema.Resource {
 }
 
 func resourceScalewayInstanceVolumeCreate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, err := getInstanceAPIWithZone(d, m)
+	instanceAPI, zone, err := instanceAPIWithZone(d, m)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func resourceScalewayInstanceVolumeCreate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayInstanceVolumeRead(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, id, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, id, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func resourceScalewayInstanceVolumeRead(d *schema.ResourceData, m interface{}) e
 }
 
 func resourceScalewayInstanceVolumeUpdate(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, id, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, id, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func resourceScalewayInstanceVolumeUpdate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayInstanceVolumeDelete(d *schema.ResourceData, m interface{}) error {
-	instanceAPI, zone, id, err := getInstanceAPIWithZoneAndID(m, d.Id())
+	instanceAPI, zone, id, err := instanceAPIWithZoneAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_k8s_cluster_beta.go
+++ b/scaleway/resource_k8s_cluster_beta.go
@@ -288,7 +288,7 @@ func resourceScalewayK8SClusterBeta() *schema.Resource {
 }
 
 func resourceScalewayK8SClusterBetaCreate(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, err := getK8SAPIWithRegion(d, m)
+	k8sAPI, region, err := k8sAPIWithRegion(d, m)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func resourceScalewayK8SClusterBetaCreate(d *schema.ResourceData, m interface{})
 // resourceScalewayK8SClusterBetaDefaultPoolRead is only called after a resourceScalewayK8SClusterBetaCreate
 // thus ensuring the uniqueness of the only pool listed
 func resourceScalewayK8SClusterBetaDefaultPoolRead(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -482,7 +482,7 @@ func resourceScalewayK8SClusterBetaDefaultPoolRead(d *schema.ResourceData, m int
 }
 
 func resourceScalewayK8SClusterBetaRead(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -565,7 +565,7 @@ func resourceScalewayK8SClusterBetaRead(d *schema.ResourceData, m interface{}) e
 // resourceScalewayK8SClusterBetaDefaultPoolUpdate is only called after a resourceScalewayK8SClusterBetaUpdate
 // thus guarating that "default_pool.id" is set
 func resourceScalewayK8SClusterBetaDefaultPoolUpdate(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -670,7 +670,7 @@ func resourceScalewayK8SClusterBetaDefaultPoolUpdate(d *schema.ResourceData, m i
 }
 
 func resourceScalewayK8SClusterBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -790,7 +790,7 @@ func resourceScalewayK8SClusterBetaUpdate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayK8SClusterBetaDelete(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_k8s_cluster_beta_test.go
+++ b/scaleway/resource_k8s_cluster_beta_test.go
@@ -292,7 +292,7 @@ func testAccCheckScalewayK8SClusterBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func testAccCheckScalewayK8SClusterBetaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		k8sAPI, region, clusterID, err := getK8SAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_k8s_pool_beta.go
+++ b/scaleway/resource_k8s_pool_beta.go
@@ -106,7 +106,7 @@ func resourceScalewayK8SPoolBeta() *schema.Resource {
 }
 
 func resourceScalewayK8SPoolBetaCreate(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, err := getK8SAPIWithRegion(d, m)
+	k8sAPI, region, err := k8sAPIWithRegion(d, m)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func resourceScalewayK8SPoolBetaCreate(d *schema.ResourceData, m interface{}) er
 }
 
 func resourceScalewayK8SPoolBetaRead(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, poolID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, poolID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func resourceScalewayK8SPoolBetaRead(d *schema.ResourceData, m interface{}) erro
 }
 
 func resourceScalewayK8SPoolBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, poolID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, poolID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ func resourceScalewayK8SPoolBetaUpdate(d *schema.ResourceData, m interface{}) er
 }
 
 func resourceScalewayK8SPoolBetaDelete(d *schema.ResourceData, m interface{}) error {
-	k8sAPI, region, poolID, err := getK8SAPIWithRegionAndID(m, d.Id())
+	k8sAPI, region, poolID, err := k8sAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_k8s_pool_beta_test.go
+++ b/scaleway/resource_k8s_pool_beta_test.go
@@ -72,7 +72,7 @@ func testAccCheckScalewayK8SPoolBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		k8sAPI, region, poolID, err := getK8SAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		k8sAPI, region, poolID, err := k8sAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ func testAccCheckScalewayK8SPoolBetaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		k8sAPI, region, poolID, err := getK8SAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		k8sAPI, region, poolID, err := k8sAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_lb_backend_beta.go
+++ b/scaleway/resource_lb_backend_beta.go
@@ -216,7 +216,7 @@ func resourceScalewayLbBackendBeta() *schema.Resource {
 }
 
 func resourceScalewayLbBackendBetaCreate(d *schema.ResourceData, m interface{}) error {
-	lbAPI := getLbAPI(m)
+	lbAPI := lbAPI(m)
 
 	region, LbID, err := parseRegionalID(d.Get("lb_id").(string))
 	if err != nil {
@@ -265,7 +265,7 @@ func resourceScalewayLbBackendBetaCreate(d *schema.ResourceData, m interface{}) 
 }
 
 func resourceScalewayLbBackendBetaRead(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func resourceScalewayLbBackendBetaRead(d *schema.ResourceData, m interface{}) er
 }
 
 func resourceScalewayLbBackendBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -370,7 +370,7 @@ func resourceScalewayLbBackendBetaUpdate(d *schema.ResourceData, m interface{}) 
 }
 
 func resourceScalewayLbBackendBetaDelete(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_lb_backend_beta_test.go
+++ b/scaleway/resource_lb_backend_beta_test.go
@@ -180,7 +180,7 @@ func testAccCheckScalewayLbBackendBetaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		lbAPI, region, ID, err := getLbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		lbAPI, region, ID, err := lbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ func testAccCheckScalewayLbBackendBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		lbAPI, region, ID, err := getLbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		lbAPI, region, ID, err := lbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_lb_beta.go
+++ b/scaleway/resource_lb_beta.go
@@ -53,7 +53,7 @@ func resourceScalewayLbBeta() *schema.Resource {
 }
 
 func resourceScalewayLbBetaCreate(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, err := getLbAPIWithRegion(d, m)
+	lbAPI, region, err := lbAPIWithRegion(d, m)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func resourceScalewayLbBetaCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScalewayLbBetaRead(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func resourceScalewayLbBetaRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScalewayLbBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func resourceScalewayLbBetaUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScalewayLbBetaDelete(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_lb_beta_test.go
+++ b/scaleway/resource_lb_beta_test.go
@@ -57,7 +57,7 @@ func testAccCheckScalewayLbBetaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		lbAPI, region, ID, err := getLbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		lbAPI, region, ID, err := lbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ func testAccCheckScalewayLbBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		lbAPI, region, ID, err := getLbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		lbAPI, region, ID, err := lbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_lb_frontend_beta.go
+++ b/scaleway/resource_lb_frontend_beta.go
@@ -63,7 +63,7 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 }
 
 func resourceScalewayLbFrontendBetaCreate(d *schema.ResourceData, m interface{}) error {
-	lbAPI := getLbAPI(m)
+	lbAPI := lbAPI(m)
 
 	region, LbID, err := parseRegionalID(d.Get("lb_id").(string))
 	if err != nil {
@@ -90,7 +90,7 @@ func resourceScalewayLbFrontendBetaCreate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayLbFrontendBetaRead(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func resourceScalewayLbFrontendBetaRead(d *schema.ResourceData, m interface{}) e
 }
 
 func resourceScalewayLbFrontendBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func resourceScalewayLbFrontendBetaUpdate(d *schema.ResourceData, m interface{})
 }
 
 func resourceScalewayLbFrontendBetaDelete(d *schema.ResourceData, m interface{}) error {
-	lbAPI, region, ID, err := getLbAPIWithRegionAndID(m, d.Id())
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_lb_frontend_beta_test.go
+++ b/scaleway/resource_lb_frontend_beta_test.go
@@ -76,7 +76,7 @@ func testAccCheckScalewayLbFrontendBetaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		lbAPI, region, ID, err := getLbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		lbAPI, region, ID, err := lbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func testAccCheckScalewayLbFrontendBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		lbAPI, region, ID, err := getLbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		lbAPI, region, ID, err := lbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_object_bucket.go
+++ b/scaleway/resource_object_bucket.go
@@ -47,7 +47,7 @@ func resourceScalewayObjectBucketCreate(d *schema.ResourceData, m interface{}) e
 	bucketName := d.Get("name").(string)
 	acl := d.Get("acl").(string)
 
-	s3Client, region, err := getS3ClientWithRegion(d, m)
+	s3Client, region, err := s3ClientWithRegion(d, m)
 
 	_, err = s3Client.CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
@@ -63,7 +63,7 @@ func resourceScalewayObjectBucketCreate(d *schema.ResourceData, m interface{}) e
 }
 
 func resourceScalewayObjectBucketRead(d *schema.ResourceData, m interface{}) error {
-	s3Client, _, bucketName, err := getS3ClientWithRegionAndName(m, d.Id())
+	s3Client, _, bucketName, err := s3ClientWithRegionAndName(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func resourceScalewayObjectBucketRead(d *schema.ResourceData, m interface{}) err
 }
 
 func resourceScalewayObjectBucketUpdate(d *schema.ResourceData, m interface{}) error {
-	s3Client, _, bucketName, err := getS3ClientWithRegionAndName(m, d.Id())
+	s3Client, _, bucketName, err := s3ClientWithRegionAndName(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func resourceScalewayObjectBucketUpdate(d *schema.ResourceData, m interface{}) e
 }
 
 func resourceScalewayObjectBucketDelete(d *schema.ResourceData, m interface{}) error {
-	s3Client, _, bucketName, err := getS3ClientWithRegionAndName(m, d.Id())
+	s3Client, _, bucketName, err := s3ClientWithRegionAndName(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_rdb_instance_beta.go
+++ b/scaleway/resource_rdb_instance_beta.go
@@ -117,7 +117,7 @@ func resourceScalewayRdbInstanceBeta() *schema.Resource {
 }
 
 func resourceScalewayRdbInstanceBetaCreate(d *schema.ResourceData, m interface{}) error {
-	rdbAPI, region, err := getRdbAPIWithRegion(d, m)
+	rdbAPI, region, err := rdbAPIWithRegion(d, m)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func resourceScalewayRdbInstanceBetaCreate(d *schema.ResourceData, m interface{}
 }
 
 func resourceScalewayRdbInstanceBetaRead(d *schema.ResourceData, m interface{}) error {
-	rdbAPI, region, ID, err := getRdbAPIWithRegionAndID(m, d.Id())
+	rdbAPI, region, ID, err := rdbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func resourceScalewayRdbInstanceBetaRead(d *schema.ResourceData, m interface{}) 
 }
 
 func resourceScalewayRdbInstanceBetaUpdate(d *schema.ResourceData, m interface{}) error {
-	rdbAPI, region, ID, err := getRdbAPIWithRegionAndID(m, d.Id())
+	rdbAPI, region, ID, err := rdbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func resourceScalewayRdbInstanceBetaUpdate(d *schema.ResourceData, m interface{}
 }
 
 func resourceScalewayRdbInstanceBetaDelete(d *schema.ResourceData, m interface{}) error {
-	rdbAPI, region, ID, err := getRdbAPIWithRegionAndID(m, d.Id())
+	rdbAPI, region, ID, err := rdbAPIWithRegionAndID(m, d.Id())
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_rdb_instance_beta_test.go
+++ b/scaleway/resource_rdb_instance_beta_test.go
@@ -83,7 +83,7 @@ func testAccCheckScalewayRdbBetaExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", n)
 		}
 
-		rdbAPI, region, ID, err := getRdbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		rdbAPI, region, ID, err := rdbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ func testAccCheckScalewayRdbInstanceBetaDestroy(s *terraform.State) error {
 			continue
 		}
 
-		rdbAPI, region, ID, err := getRdbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
+		rdbAPI, region, ID, err := rdbAPIWithRegionAndID(testAccProvider.Meta(), rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_ssh_key.go
+++ b/scaleway/resource_ssh_key.go
@@ -31,7 +31,7 @@ func resourceScalewaySSHKey() *schema.Resource {
 	}
 }
 
-func getSSHKeyFingerprint(key []byte) (string, error) {
+func sshKeyFingerprint(key []byte) (string, error) {
 	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(key)
 	if err != nil {
 		return "", err
@@ -42,7 +42,7 @@ func getSSHKeyFingerprint(key []byte) (string, error) {
 func resourceScalewaySSHKeyCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Meta).deprecatedClient
 
-	fingerprint, err := getSSHKeyFingerprint([]byte(d.Get("key").(string)))
+	fingerprint, err := sshKeyFingerprint([]byte(d.Get("key").(string)))
 	if err != nil {
 		return err
 	}

--- a/scaleway/resource_ssh_key_test.go
+++ b/scaleway/resource_ssh_key_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGetSSHKeyFingerprint(t *testing.T) {
 	key := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYpDmIzRs5c+xs0jmljMbNYVcgV8fRruMCRDA4HKjGN2lqLTZhngGDXsdt/2kTNQQPAq2sR4N8mfX5wMRT/+jNb+8esPyY5WlElni0zmD7oLoPW4lYRES6f7EeAv6NttLfkDO42r15OtMnglcgWk1u4o3lOXuLbhzJT1qdicpDja22X3uR/xUy1AYhKBOoiSlQbkb7NhL0lA1xQNwerdaJJS8tFB+wViVDyP0f1HaIRxViFlTGuTbTuIJNR/7VJ9VBBuTnYXaRkPxz64sUXrtdVK8U0+4KsisyXwmgQKnvZBDj91wxz12OOzFSQ52iFprIj1JbkzuBmNWXUGKYzXJZ nicolai86@test")
-	fingerprint, err := getSSHKeyFingerprint(key)
+	fingerprint, err := sshKeyFingerprint(key)
 
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err.Error())


### PR DESCRIPTION
The [Effective Go document](https://golang.org/doc/effective_go.html#Getters) states it is unnecessary to put a Get (or get in this case) prefix before the getter's name.

As Effective Go is the closest we have to an official Go styleguide,
and while officially it makes only "tips on writing clear, idiomatic Go code",
it makes reading Go consistent across projects. The get prefix is neither
idiomatic or needed.