### PR TITLE
fix(object): import bucket by name

### DIFF
--- a/scaleway/helper_storage_object.go
+++ b/scaleway/helper_storage_object.go
@@ -31,13 +31,13 @@ func getS3ClientWithRegion(d *schema.ResourceData, m interface{}) (*s3.S3, scw.R
 	return meta.s3Client, region, err
 }
 
-// getS3ClientWithRegion returns a new S3 client with the correct region and id  extracted from the resource data.
-func getS3ClientWithRegionAndID(m interface{}, id string) (*s3.S3, scw.Region, string, error) {
+// getS3ClientWithRegion returns a new S3 client with the correct region and name extracted from the resource data.
+func getS3ClientWithRegionAndName(m interface{}, name string) (*s3.S3, scw.Region, string, error) {
 	meta := m.(*Meta)
 
-	region, id, err := parseRegionalID(id)
+	region, name, err := parseRegionalID(name)
 	if err != nil {
-		return nil, "", id, err
+		return nil, "", name, err
 	}
 
 	if region != meta.DefaultRegion {
@@ -48,11 +48,11 @@ func getS3ClientWithRegionAndID(m interface{}, id string) (*s3.S3, scw.Region, s
 
 		err := newMeta.bootstrapS3Client()
 		if err != nil {
-			return nil, "", id, err
+			return nil, "", name, err
 		}
-		return newMeta.s3Client, region, id, nil
+		return newMeta.s3Client, region, name, nil
 	}
 
-	return meta.s3Client, region, id, err
+	return meta.s3Client, region, name, err
 
 }

--- a/website/docs/r/object_bucket.html.markdown
+++ b/website/docs/r/object_bucket.html.markdown
@@ -30,12 +30,12 @@ The following arguments are supported:
 
 In addition to all above arguments, the following attribute is exported:
 	
-* `id` - The ID of the bucket.
+* `id` - The unique name of the bucket.
 
 ## Import
 
-Buckets can be imported using the `{region}/{id}` identifier, e.g.
+Buckets can be imported using the `{region}/{bucketName}` identifier, e.g.
 
-```
-$ terraform import scaleway_object_bucket.some_bucket fr-par/11111111-1111-1111-1111-111111111111
+```bash
+$ terraform import scaleway_object_bucket.some_bucket fr-par/some-bucket
 ```


### PR DESCRIPTION
* Rename `getS3ClientWithRegionAndID` to `getS3ClientWithRegionAndName` as the resource ID il the name of the bucket.
* Use [aws-sdk-go constants](https://godoc.org/github.com/aws/aws-sdk-go/service/s3#pkg-constants) for `acl` attribute validatation function.
* Remove `bucket-owner-read` and `bucket-owner-full-control` canned ACL support as they are applied to objects and not buckets ([source](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl)).
* Remove `log-delivery-write` canned ACL support as it is not supported in the aws-sdk-go. We could re-add it if needed. 

Closes #321 