### PR TITLE
doc: fix index example

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -39,7 +39,8 @@ resource "scaleway_instance_ip" "public_ip" {
 }
 
 resource "scaleway_instance_volume" "data" {
-  size_in_gb = 100
+  size_in_gb = 30
+  type = "l_ssd"
 }
 
 resource "scaleway_instance_security_group" "www" {


### PR DESCRIPTION
scaleway_instance_volume.type is required

The total size of local-volume(s) of instances DEV1-L must be equal to 80GB