### PR TITLE
doc: clean up documentation

### DIFF
--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -20,7 +20,7 @@ data "scaleway_image" "ubuntu" {
 
 resource "scaleway_server" "base" {
   name  = "test"
-  image = "${data.scaleway_image.ubuntu.id}"
+  image = data.scaleway_image.ubuntu.id
   type  = "C1"
 }
 ```

--- a/website/docs/d/volume.html.markdown
+++ b/website/docs/d/volume.html.markdown
@@ -21,8 +21,8 @@ resource "scaleway_server" "test" {
 }
 
 resource "scaleway_volume_attachment" "data" {
-  server = "${scaleway_server.test.id}"
-  volume = "${scaleway_volume.data.id}"
+  server = scaleway_server.test.id
+  volume = scaleway_volume.data.id
 }
 ```
 

--- a/website/docs/guides/migration_guide_v2.html.markdown
+++ b/website/docs/guides/migration_guide_v2.html.markdown
@@ -93,7 +93,7 @@ resource "scaleway_instance_volume" "data" {
 
 resource "scaleway_instance_server" "web" {
   type = "DEV1-L"
-  image = "f974feac-abae-4365-b988-8ec7d1cec10d"
+  image = "ubuntu-bionic"
 
   tags = [ "hello", "public" ]
 
@@ -101,7 +101,7 @@ resource "scaleway_instance_server" "web" {
     delete_on_termination = false
   }
 
-  additional_volume_ids = [ "${scaleway_instance_volume.data.id}" ]
+  additional_volume_ids = [ scaleway_instance_volume.data.id ]
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -27,15 +27,15 @@ You can test this config by creating a `test.tf` and run terraform commands from
 
 ```hcl
 provider "scaleway" {
-  access_key = "<SCALEWAY-ACCESS-KEY>"
-  secret_key = "<SCALEWAY-SECRET-KEY>"
+  access_key      = "<SCALEWAY-ACCESS-KEY>"
+  secret_key      = "<SCALEWAY-SECRET-KEY>"
   organization_id = "<SCALEWAY-ORGANIZATION-ID>"
-  zone       = "fr-par-1"
-  region     = "fr-par"
+  zone            = "fr-par-1"
+  region          = "fr-par"
 }
 
 resource "scaleway_instance_ip" "public_ip" {
-  server_id = "${scaleway_instance_server.web.id}"
+  server_id = scaleway_instance_server.web.id
 }
 
 resource "scaleway_instance_volume" "data" {
@@ -43,35 +43,35 @@ resource "scaleway_instance_volume" "data" {
 }
 
 resource "scaleway_instance_security_group" "www" {
-  inbound_default_policy = "drop"
+  inbound_default_policy  = "drop"
   outbound_default_policy = "accept"
 
   inbound_rule {
     action = "accept"
-    port = "22"
-    ip = "212.47.225.64"
+    port   = "22"
+    ip     = "212.47.225.64"
   }
 
   inbound_rule {
     action = "accept"
-    port = "80"
+    port   = "80"
   }
 
   inbound_rule {
     action = "accept"
-    port = "443"
+    port   = "443"
   }
 }
 
 resource "scaleway_instance_server" "web" {
-  type = "DEV1-L"
+  type  = "DEV1-L"
   image = "ubuntu-bionic"
 
   tags = [ "front", "web" ]
 
-  additional_volume_ids = [ "${scaleway_instance_volume.data.id}" ]
+  additional_volume_ids = [ scaleway_instance_volume.data.id ]
 
-  security_group_id= "${scaleway_instance_security_group.www.id}"
+  security_group_id = scaleway_instance_security_group.www.id
 }
 ```
 
@@ -164,14 +164,14 @@ Configure your backend as:
 ```
 terraform {
   backend "s3" {
-    bucket      = "terraform_state"
-    key         = "my_state.tfstate"
-    region      = "fr-par"
-    endpoint    = "https://s3.fr-par.scw.cloud"
-    access_key = "my-access-key"
-    secret_key = "my-secret-key"
+    bucket                      = "terraform_state"
+    key                         = "my_state.tfstate"
+    region                      = "fr-par"
+    endpoint                    = "https://s3.fr-par.scw.cloud"
+    access_key                  = "my-access-key"
+    secret_key                  = "my-secret-key"
     skip_credentials_validation = true
-    skip_region_validation = true
+    skip_region_validation      = true
   }
 }
 ```

--- a/website/docs/r/instance_server.html.markdown
+++ b/website/docs/r/instance_server.html.markdown
@@ -15,12 +15,12 @@ Creates and manages Scaleway Compute Instance servers. For more information, see
 
 ```hcl
 resource "scaleway_instance_ip" "public_ip" {
-  server_id = "${scaleway_instance_server.web.id}"
+  server_id = scaleway_instance_server.web.id
 }
 
 resource "scaleway_instance_server" "web" {
   type = "DEV1-S"
-  image = "f974feac-abae-4365-b988-8ec7d1cec10d"
+  image = "ubuntu-bionic"
 }
 ```
 
@@ -33,7 +33,7 @@ resource "scaleway_instance_volume" "data" {
 
 resource "scaleway_instance_server" "web" {
   type = "DEV1-L"
-  image = "f974feac-abae-4365-b988-8ec7d1cec10d"
+  image = "ubuntu-bionic"
 
   tags = [ "hello", "public" ]
 
@@ -41,7 +41,7 @@ resource "scaleway_instance_server" "web" {
     delete_on_termination = false
   }
 
-  additional_volume_ids = [ "${scaleway_instance_volume.data.id}" ]
+  additional_volume_ids = [ scaleway_instance_volume.data.id ]
 }
 ```
 
@@ -76,9 +76,9 @@ resource "scaleway_instance_security_group" "www" {
 
 resource "scaleway_instance_server" "web" {
   type = "DEV1-S"
-  image = "f974feac-abae-4365-b988-8ec7d1cec10d"
+  image = "ubuntu-bionic"
 
-  security_group_id= "${scaleway_instance_security_group.www.id}"
+  security_group_id= scaleway_instance_security_group.www.id
 }
 ```
 
@@ -87,7 +87,7 @@ resource "scaleway_instance_server" "web" {
 ```hcl
 resource "scaleway_instance_server" "web" {
   type = "DEV1-L"
-  image = "f974feac-abae-4365-b988-8ec7d1cec10d"
+  image = "ubuntu-bionic"
 
   tags = [ "web", "public" ]
 

--- a/website/docs/r/ip_reverse_dns.html.markdown
+++ b/website/docs/r/ip_reverse_dns.html.markdown
@@ -19,7 +19,7 @@ For additional details please refer to [API documentation](https://developer.sca
 resource "scaleway_ip" "test_service" {}
 
 resource "scaleway_ip_reverse_dns" "google" {
-  ip = "${scaleway_ip.test_service.id}"
+  ip = scaleway_ip.test_service.id
   reverse = "test_service.awesome-corp.com"
 }
 ```

--- a/website/docs/r/k8s_pool_beta.html.markdown
+++ b/website/docs/r/k8s_pool_beta.html.markdown
@@ -25,7 +25,7 @@ resource "scaleway_k8s_cluster_beta" "jack" {
 }
 
 resource "scaleway_k8s_pool_beta" "bill" {
-  cluster_id = "${scaleway_k8s_cluster_beta.jack.id}"
+  cluster_id = scaleway_k8s_cluster_beta.jack.id
   name = "bill"
   node_type = "GP1-S"
   size = 3

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -22,7 +22,7 @@ resource "scaleway_security_group" "test" {
 }
 
 resource "scaleway_security_group_rule" "smtp_drop_1" {
-  security_group = "${scaleway_security_group.test.id}"
+  security_group = scaleway_security_group.test.id
 
   action    = "accept"
   direction = "inbound"

--- a/website/docs/r/user_data.html.markdown
+++ b/website/docs/r/user_data.html.markdown
@@ -25,7 +25,7 @@ resource "scaleway_server" "base" {
 }
 
 resource "scaleway_user_data" "gcp" {
-	server = "${scaleway_server.base.id}"
+	server = scaleway_server.base.id
 	key = "gcp_username"
 	value = "supersecret"
 }

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -20,7 +20,7 @@ resource "scaleway_server" "test" {
   name    = "test"
   image   = "aecaed73-51a5-4439-a127-6d8229847145"
   type    = "C2S"
-  volumes = ["${scaleway_volume.test.id}"]
+  volumes = [scaleway_volume.test.id]
 }
 
 resource "scaleway_volume" "test" {

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -30,8 +30,8 @@ resource "scaleway_volume" "test" {
 }
 
 resource "scaleway_volume_attachment" "test" {
-  server = "${scaleway_server.test.id}"
-  volume = "${scaleway_volume.test.id}"
+  server = scaleway_server.test.id
+  volume = scaleway_volume.test.id
 }
 ```
 


### PR DESCRIPTION
- Remove deprecated [interpolation syntax](https://www.terraform.io/docs/configuration-0-11/interpolation.html).
- Use `scaleway_instance_server.image = "ubuntu"` insteaf of an UUID.
- Improve example indentations
