### PR TITLE
feat(k8s): wait for pool to be ready and add 'nodes' in its output

### DIFF
--- a/scaleway/helpers_k8s.go
+++ b/scaleway/helpers_k8s.go
@@ -37,6 +37,7 @@ type KubeconfigStruct struct {
 const (
 	K8SClusterWaitForReadyTimeout   = 10 * time.Minute
 	K8SClusterWaitForDeletedTimeout = 10 * time.Minute
+	K8SPoolWaitForReadyTimeout      = 10 * time.Minute
 )
 
 func k8sAPIWithRegion(d *schema.ResourceData, m interface{}) (*k8s.API, scw.Region, error) {
@@ -69,7 +70,7 @@ func waitK8SClusterReady(k8sAPI *k8s.API, region scw.Region, clusterID string) e
 	if cluster.Status == k8s.ClusterStatusReady {
 		return nil
 	}
-	return fmt.Errorf("Cluster %s has state %s, wants %s", clusterID, cluster.Status.String(), k8s.ClusterStatusReady.String())
+	return fmt.Errorf("cluster %s has state %s, wants %s", clusterID, cluster.Status, k8s.ClusterStatusReady)
 }
 
 func waitK8SClusterDeleted(k8sAPI *k8s.API, region scw.Region, clusterID string) error {
@@ -85,7 +86,58 @@ func waitK8SClusterDeleted(k8sAPI *k8s.API, region scw.Region, clusterID string)
 		return err
 	}
 
-	return fmt.Errorf("Cluster %s has state %s, wants %s", clusterID, cluster.Status.String(), k8s.ClusterStatusDeleted.String())
+	return fmt.Errorf("cluster %s has state %s, wants %s", clusterID, cluster.Status, k8s.ClusterStatusDeleted)
+}
+
+func waitK8SPoolReady(k8sAPI *k8s.API, region scw.Region, poolID string) error {
+	pool, err := k8sAPI.WaitForPool(&k8s.WaitForPoolRequest{
+		PoolID:  poolID,
+		Region:  region,
+		Timeout: scw.DurationPtr(K8SPoolWaitForReadyTimeout),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if pool.Status == k8s.PoolStatusReady {
+		return nil
+	}
+	return fmt.Errorf("pool %s has state %s, wants %s", poolID, pool.Status, k8s.PoolStatusReady)
+}
+
+// convert a list of nodes to a list of map
+func convertNodes(res *k8s.ListNodesResponse) []map[string]interface{} {
+	var result []map[string]interface{}
+	for _, node := range res.Nodes {
+		n := make(map[string]interface{})
+		n["name"] = node.Name
+		n["status"] = node.Status.String()
+		if node.PublicIPV4 != nil && node.PublicIPV4.String() != "<nil>" {
+			n["public_ip"] = node.PublicIPV4.String()
+		}
+		if node.PublicIPV6 != nil && node.PublicIPV6.String() != "<nil>" {
+			n["public_ip_v6"] = node.PublicIPV6.String()
+		}
+		result = append(result, n)
+	}
+	return result
+}
+
+func getNodes(k8sAPI *k8s.API, pool *k8s.Pool) ([]map[string]interface{}, error) {
+	req := &k8s.ListNodesRequest{
+		Region:    pool.Region,
+		ClusterID: pool.ClusterID,
+		PoolID:    &pool.ID,
+	}
+
+	nodes, err := k8sAPI.ListNodes(req, scw.WithAllPages())
+
+	if err != nil {
+		return nil, err
+	}
+
+	return convertNodes(nodes), nil
 }
 
 func clusterAutoscalerConfigFlatten(cluster *k8s.Cluster) []map[string]interface{} {

--- a/website/docs/r/k8s_cluster_beta.html.markdown
+++ b/website/docs/r/k8s_cluster_beta.html.markdown
@@ -151,6 +151,8 @@ The following arguments are supported:
   - `container_runtime` - (Defaults to `docker`) The container runtime of the default pool.
 ~> **Important:** Updates to this field will recreate a new default pool.
 
+  - `wait_for_pool_ready` - (Default to `false`) Whether to wait for the pool to be ready.
+
 - `region` - (Defaults to [provider](../index.html#region) `region`) The [region](../guides/regions_and_zones.html#regions) in which the cluster should be created.
 
 - `organization_id` - (Defaults to [provider](../index.html#organization_id) `organization_id`) The ID of the organization the cluster is associated with.
@@ -173,6 +175,12 @@ In addition to all above arguments, the following attributes are exported:
 - `status` - The status of the Kubernetes cluster.
 - `default_pool`
   - `pool_id` - The ID of the default pool.
+  - `status` - The status of the default pool.
+  - `nodes` - (List of) The nodes in the default pool.
+    - `name` - The name of the node.
+    - `public_ip` - The public IPv4.
+    - `public_ip_v6` - The public IPv6.
+    - `status` - The status of the node.
   - `created_at` - The creation date of the default pool.
   - `updated_at` - The last update date of the default pool.
 - `upgrade_available` - Set to `true` if a newer Kubernetes version is available.

--- a/website/docs/r/k8s_pool_beta.html.markdown
+++ b/website/docs/r/k8s_pool_beta.html.markdown
@@ -67,11 +67,19 @@ The following arguments are supported:
 
 - `region` - (Defaults to [provider](../index.html#region) `region`) The [region](../guides/regions_and_zones.html#regions) in which the pool should be created.
 
+- `wait_for_pool_ready` - (Default to `false`) Whether to wait for the pool to be ready.
+
 ## Attributes Reference
 
 In addition to all above arguments, the following attributes are exported:
 
 - `id` - The ID of the pool.
+- `status` - The status of the pool.
+- `nodes` - (List of) The nodes in the default pool.
+  - `name` - The name of the node.
+  - `public_ip` - The public IPv4.
+  - `public_ip_v6` - The public IPv6.
+  - `status` - The status of the node.
 - `created_at` - The creation date of the pool.
 - `updated_at` - The last update date of the pool.
 - `version` - The version of the pool.


### PR DESCRIPTION
~~Depends on https://github.com/scaleway/scaleway-sdk-go/pull/312~~

~~To test with the *scaleway-sdk-go* patch from https://github.com/scaleway/scaleway-sdk-go/pull/312, 
 run:~~
```
echo 'replace github.com/scaleway/scaleway-sdk-go => github.com/debovema/scaleway-sdk-go wait-for-nodes' >> go.mod
```

=> https://github.com/scaleway/scaleway-sdk-go/pull/312 was merged