### PR TITLE
feat: added certificate to load-balancer

### DIFF
--- a/scaleway/helpers_lb.go
+++ b/scaleway/helpers_lb.go
@@ -200,10 +200,39 @@ func expandLbHCHTTPS(raw interface{}) *lb.HealthCheckHTTPSConfig {
 	if raw == nil || len(raw.([]interface{})) != 1 {
 		return nil
 	}
+
 	rawMap := raw.([]interface{})[0].(map[string]interface{})
 	return &lb.HealthCheckHTTPSConfig{
 		URI:    rawMap["uri"].(string),
 		Method: rawMap["method"].(string),
 		Code:   expandInt32Ptr(rawMap["code"]),
 	}
+}
+
+func expandLbLetsEncrypt(raw interface{}) *lb.CreateCertificateRequestLetsencryptConfig {
+	if raw == nil || len(raw.([]interface{})) != 1 {
+		return nil
+	}
+
+	rawMap := raw.([]interface{})[0].(map[string]interface{})
+	alternativeNames := rawMap["subject_alternative_name"].([]interface{})
+	config := &lb.CreateCertificateRequestLetsencryptConfig{
+		CommonName: rawMap["common_name"].(string),
+	}
+	for _, alternativeName := range alternativeNames {
+		config.SubjectAlternativeName = append(config.SubjectAlternativeName, alternativeName.(string))
+	}
+	return config
+}
+
+func expandLbCustomCertificate(raw interface{}) *lb.CreateCertificateRequestCustomCertificate {
+	if raw == nil || len(raw.([]interface{})) != 1 {
+		return nil
+	}
+
+	rawMap := raw.([]interface{})[0].(map[string]interface{})
+	config := &lb.CreateCertificateRequestCustomCertificate{
+		CertificateChain: rawMap["certificate_chain"].(string),
+	}
+	return config
 }

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -201,6 +201,7 @@ func Provider() terraform.ResourceProvider {
 			"scaleway_k8s_pool_beta":                 resourceScalewayK8SPoolBeta(),
 			"scaleway_lb_beta":                       resourceScalewayLbBeta(),
 			"scaleway_lb_backend_beta":               resourceScalewayLbBackendBeta(),
+			"scaleway_lb_certificate_beta":           resourceScalewayLbCertificateBeta(),
 			"scaleway_lb_frontend_beta":              resourceScalewayLbFrontendBeta(),
 			"scaleway_registry_namespace_beta":       resourceScalewayRegistryNamespaceBeta(),
 			"scaleway_rdb_instance_beta":             resourceScalewayRdbInstanceBeta(),

--- a/scaleway/resource_lb_certificate_beta.go
+++ b/scaleway/resource_lb_certificate_beta.go
@@ -1,0 +1,201 @@
+package scaleway
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/scaleway/scaleway-sdk-go/api/lb/v1"
+)
+
+func resourceScalewayLbCertificateBeta() *schema.Resource {
+	return &schema.Resource{
+		Create:        resourceScalewayLbCertificateBetaCreate,
+		Read:          resourceScalewayLbCertificateBetaRead,
+		Update:        resourceScalewayLbCertificateBetaUpdate,
+		Delete:        resourceScalewayLbCertificateBetaDelete,
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"lb_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The load-balancer ID",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the load-balancer certificate",
+				Optional:    true,
+				Computed:    true,
+			},
+			"letsencrypt": {
+				ConflictsWith: []string{"custom_certificate"},
+				MaxItems:      1,
+				Description:   "The Let's Encrypt type certificate configuration",
+				Type:          schema.TypeList,
+				Optional:      true,
+				ForceNew:      true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"common_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The main domain name of the certificate",
+						},
+						"subject_alternative_name": {
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Optional:    true,
+							Description: "The alternative domain names of the certificate",
+						},
+					},
+				},
+			},
+			"custom_certificate": {
+				ConflictsWith: []string{"letsencrypt"},
+				MaxItems:      1,
+				Type:          schema.TypeList,
+				Description:   "The custom type certificate type configuration",
+				Optional:      true,
+				ForceNew:      true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"certificate_chain": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The full PEM-formatted certificate chain",
+						},
+					},
+				},
+			},
+
+			// Readonly attributes
+			"common_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The main domain name of the certificate",
+			},
+			"subject_alternative_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alternative domain names of the certificate",
+			},
+			"fingerprint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The identifier (SHA-1) of the certificate",
+			},
+			"not_valid_before": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The not valid before validity bound timestamp",
+			},
+			"not_valid_after": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The not valid after validity bound timestamp",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of certificate",
+			},
+		},
+	}
+}
+
+func resourceScalewayLbCertificateBetaCreate(d *schema.ResourceData, m interface{}) error {
+	region, lbID, err := parseRegionalID(d.Get("lb_id").(string))
+	if err != nil {
+		return err
+	}
+
+	createReq := &lb.CreateCertificateRequest{
+		Region:            region,
+		LbID:              lbID,
+		Name:              expandOrGenerateString(d.Get("name"), "lb-cert"),
+		Letsencrypt:       expandLbLetsEncrypt(d.Get("letsencrypt")),
+		CustomCertificate: expandLbCustomCertificate(d.Get("custom_certificate")),
+	}
+	if createReq.Letsencrypt == nil && createReq.CustomCertificate == nil {
+		return errors.New("you need to define either letsencrypt or custom_certificate configuration")
+	}
+
+	lbAPI := lbAPI(m)
+	res, err := lbAPI.CreateCertificate(createReq)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(newRegionalId(region, res.ID))
+
+	return resourceScalewayLbCertificateBetaRead(d, m)
+}
+
+func resourceScalewayLbCertificateBetaRead(d *schema.ResourceData, m interface{}) error {
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
+	if err != nil {
+		return err
+	}
+
+	res, err := lbAPI.GetCertificate(&lb.GetCertificateRequest{
+		CertificateID: ID,
+		Region:        region,
+	})
+
+	if err != nil {
+		if is404Error(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	_ = d.Set("name", res.Name)
+	_ = d.Set("common_name", res.CommonName)
+	_ = d.Set("subject_alternative_name", res.SubjectAlternativeName)
+	_ = d.Set("fingerprint", res.Fingerprint)
+	_ = d.Set("not_valid_before", flattenTime(&res.NotValidBefore))
+	_ = d.Set("not_valid_after", flattenTime(&res.NotValidAfter))
+	_ = d.Set("status", res.Status)
+	return nil
+}
+
+func resourceScalewayLbCertificateBetaUpdate(d *schema.ResourceData, m interface{}) error {
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
+	if err != nil {
+		return err
+	}
+
+	req := &lb.UpdateCertificateRequest{
+		CertificateID: ID,
+		Region:        region,
+		Name:          d.Get("name").(string),
+	}
+
+	_, err = lbAPI.UpdateCertificate(req)
+	if err != nil {
+		return err
+	}
+
+	return resourceScalewayLbCertificateBetaRead(d, m)
+}
+
+func resourceScalewayLbCertificateBetaDelete(d *schema.ResourceData, m interface{}) error {
+	lbAPI, region, ID, err := lbAPIWithRegionAndID(m, d.Id())
+	if err != nil {
+		return err
+	}
+
+	err = lbAPI.DeleteCertificate(&lb.DeleteCertificateRequest{
+		Region:        region,
+		CertificateID: ID,
+	})
+
+	if err != nil && !is404Error(err) {
+		return err
+	}
+
+	return nil
+}

--- a/scaleway/resource_lb_certificate_beta_test.go
+++ b/scaleway/resource_lb_certificate_beta_test.go
@@ -1,0 +1,141 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccScalewayLbCertificateBeta(t *testing.T) {
+	/**
+	* Note regarding the usage of xip.io
+	* See the discussion on https://github.com/terraform-providers/terraform-provider-scaleway/pull/396
+	* Long story short, scaleway API will not permit you to request a certificate in case common name is not pointed
+	* to the load balancer IP (which is unknown before creating it). In production, this can be overcome by introducing
+	* an additional step which creates a DNS record and depending on it, but for test purposes, xip.io is an ideal solution.
+	 */
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayLbBetaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource scaleway_lb_beta lb01 {
+						name = "test-lb"
+						type = "lb-s"
+					}
+					resource scaleway_lb_certificate_beta cert01 {
+						lb_id = scaleway_lb_beta.lb01.id
+						name = "test-cert"
+					  	letsencrypt {
+							common_name = "${scaleway_lb_beta.lb01.ip_address}.xip.io"
+					  	}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "name", "test-cert"),
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "letsencrypt.#", "1"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_lb_beta lb01 {
+						name = "test-lb"
+						type = "lb-s"
+					}
+					resource scaleway_lb_certificate_beta cert01 {
+						lb_id = scaleway_lb_beta.lb01.id
+						name = "test-cert-new"
+					  	letsencrypt {
+							common_name = "${scaleway_lb_beta.lb01.ip_address}.xip.io"
+					  	}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "name", "test-cert-new"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_lb_beta lb01 {
+						name = "test-lb"
+						type = "lb-s"
+					}
+					resource scaleway_lb_certificate_beta cert01 {
+						lb_id = scaleway_lb_beta.lb01.id
+						name = "test-cert"
+					  	letsencrypt {
+							common_name = "${scaleway_lb_beta.lb01.ip_address}.xip.io"
+							subject_alternative_name = [
+							  "sub1.${scaleway_lb_beta.lb01.ip_address}.xip.io",
+							  "sub2.${scaleway_lb_beta.lb01.ip_address}.xip.io"
+							]
+					  	}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "name", "test-cert"),
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "letsencrypt.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "letsencrypt.0.subject_alternative_name.#", "2"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_lb_beta lb01 {
+						name = "test-lb"
+						type = "lb-s"
+					}
+					resource scaleway_lb_certificate_beta cert01 {
+						lb_id = scaleway_lb_beta.lb01.id
+						name = "test-custom-cert"
+					  	custom_certificate {
+							certificate_chain = <<EOF
+-----BEGIN CERTIFICATE REQUEST-----
+MIIBZTCBzwIBADAmMQwwCgYDVQQKDANCYXIxFjAUBgNVBAMMDSouZXhhbXBsZS5j
+b20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKM8iE+6xpL9ps2x/W/+0wf3
++5Kgcwl+AoqUTNmAT6eaLfj3PMtdAmN+IcGsYXK2F1FENAdfHd70m4mSBoMJeq+F
+a2ZEYp+RlFQqldTBSUBld48z9DNkbNmb0cMyVmntnKhPZ5wjNjgsYee2Leesm2lx
+Gw2BCpDxGLBmwKFca3bTAgMBAAGgADANBgkqhkiG9w0BAQsFAAOBgQBbelf1jYNX
+Y+AbCpbsySJ32iDtlrZkcIDHMlRIefnoXnO8B1RiEY0SU/n/b2tFCAcvkhq0whKj
+RPOH6lzT0x3lWxI+C6xpVyURlljHPygVRbD3fig1rFnH3sI2IE3fJEbGJdmmHacA
+BRgm3RR+HWWLKB0ygUbOtZk0BLBUqPK+WQ==
+-----END CERTIFICATE REQUEST-----
+-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQCjPIhPusaS/abNsf1v/tMH9/uSoHMJfgKKlEzZgE+nmi349zzL
+XQJjfiHBrGFythdRRDQHXx3e9JuJkgaDCXqvhWtmRGKfkZRUKpXUwUlAZXePM/Qz
+ZGzZm9HDMlZp7ZyoT2ecIzY4LGHnti3nrJtpcRsNgQqQ8RiwZsChXGt20wIDAQAB
+AoGBAINGbhU4jvOtW9T2fGvyEgLJkp7zvC/5D9Akvbz5LJYML0aWhmTB0ubyi/E2
+UVQwToZDhFgdTWd9bgxvzB7bo7Z1kiKWTXQSUDTjC3fchE12UU+1/s0LGh9B1cpV
+YqFAu7QNG4maXdZ2h+u+T7dioHslS74PFCBExClkwDiUsdcRAkEAzufrw6zgC0R3
+x6OMaaPsH2oX9KfR0+Kxj2m02TnwyFPSrSlIGfoSVtU5wBkvCwTBx/IPY70vNw3f
+fPacJNldGwJBAMn3/2nqMJUhR3U7bZA3lI+T1z01D7dLbvCafh3oHTYRAbHO2f0z
+k1uhn1+2r9QICwaugZwvx7biCfT3rTqXAKkCQGbINwphWnq+bHI0AJCJ6cZBQd07
+cLS9LE99x2URr1cUrNdwZmzhGTMhgSq4V/I1Tr4wtQxq8oV60saVC0QS5nkCQQDI
+W2NfuNlVN9xhqgC4zspr3KfrqlXa6dQ2j6yJEpjX5+scby3Fh4Kpph4qn1qyJwB5
+MmiVfrjK7lYeVA3fT6lxAkAc1QlmGapJ3w9996v6OZ3UqNBzsHsMmze/zGemdMfc
+VaSSB5OL7dZ8fLoJctv9EwgIBM3LFhSgAm9ASPHHR9fp
+-----END RSA PRIVATE KEY-----
+----BEGIN TRUSTED CERTIFICATE-----
+MIIBmTCCAQICCQCb2NiBTIlkeTANBgkqhkiG9w0BAQUFADARMQ8wDQYDVQQKDAZG
+b29CYXIwHhcNMjAwMzAzMTYwODQ4WhcNMzAwMzAxMTYwODQ4WjARMQ8wDQYDVQQK
+DAZGb29CYXIwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALba1p/3sJ3E2J0J
+Wa6N4Zw9aBAq4OedYszUCYqviG6XiCKZPeI1skfD9bef4pYG67R5OcccCsjwqfT4
+HkwKj/2SG4VsJZpvVr9S1uOeiA70KywB9GvuiLZUflrDEy4IEA0s6UBALRgXllX+
+QbnE8VC9brzgepQwO6tTU1Vjo9s9AgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAelXe
+TxdxZWXZFldVl7LUS39lsc9CRgIcLbmk/s23zs92zyJcYvarulx2ku4Zrp507RzT
+hPrE4kljWeyQnwIXeOSg5UZrsRtRxUTDLBtOrL3PmFZhBaDShSc+1DS4U/kjy/k+
+F+6t5ymALbasChWwC7FFgSsF5PtGP4PxZHFdXiE=
+-----END TRUSTED CERTIFICATE-----
+EOF
+					  	}
+					} 
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "name", "test-custom-cert"),
+					resource.TestCheckResourceAttr("scaleway_lb_certificate_beta.cert01", "custom_certificate.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/website/docs/r/lb_certificate_beta.html.markdown
+++ b/website/docs/r/lb_certificate_beta.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: scaleway_lb_certificate_beta"
+description: |-
+  Manages Scaleway Load-Balancer Certificates.
+---
+
+# scaleway_lb_certificate_beta
+
+-> **Note:** This terraform resource is flagged beta and might include breaking change in future releases.
+
+Creates and manages Scaleway Load-Balancer Certificates. For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/api).
+
+## Examples
+    
+#### Let's Encrypt
+```hcl
+resource scaleway_lb_certificate_beta cert01 {
+    lb_id = scaleway_lb_beta.lb01.id
+    name = "cert1"
+    letsencrypt {
+        common_name = "example.org"
+        subject_alternative_name = [
+          "sub1.example.com",
+          "sub2.example.com"
+        ]
+    }
+}
+```
+
+#### Custom Certificate
+```hcl
+resource scaleway_lb_certificate_beta cert01 {
+    lb_id = scaleway_lb_beta.lb01.id
+    name = "custom-cert"
+    custom_certificate {
+        certificate_chain = <<EOF
+CERTIFICATE_CHAIN_CONTENTS
+EOF
+    }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+### Basic arguments
+
+- `lb_id` - (Required) The load-balancer ID this certificate is attached to.
+
+~> **Important:** Updates to `lb_id` will recreate the load-balancer certificate.
+
+- `name` - (Optional) The name of the certificate backend.
+
+- `letsencrypt` - (Optional) Configuration block for Let's Encrypt configuration. Only one of `letsencrypt` and `custom_certificate` should be specified.
+
+    - `common_name` - (Required) Main domain of the certificate.
+
+    - `subject_alternative_name` - (Optional) Array of alternative domain names.
+
+~> **Important:** Updates to `letsencrypt` will recreate the load-balancer certificate.
+
+- `custom_certificate` - (Optional) Configuration block for custom certificate chain. Only one of `letsencrypt` and `custom_certificate` should be specified.
+
+    - `certificate_chain` - (Required) Full PEM-formatted certificate chain.
+
+~> **Important:** Updates to `custom_certificate` will recreate the load-balancer certificate.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of the loadbalancer certificate.
+- `common_name` - Main domain of the certificate
+- `subject_alternative_name` - The alternative domain names of the certificate
+- `fingerprint` - The identifier (SHA-1) of the certificate
+- `not_valid_before` - The not valid before validity bound timestamp
+- `not_valid_after` - The not valid after validity bound timestamp
+- `status` - Certificate status
+
+## Additional notes
+
+* Ensure that all domain names used in configuration are pointing to the load balancer IP. You can achieve this by creating a DNS record through terraform pointing to  `ip_adress` property of `lb_beta` entity
+* In case there are any issues with the certificate, you will receive a `400` error from the `apply` operation. Use `export TF_LOG=DEBUG`  to view exact problem returned by the api.
+* Wildcards are not supported with Let's Encrypt yet.

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -143,6 +143,9 @@
               <a href="/docs/providers/scaleway/r/lb_backend_beta.html">scaleway_lb_backend_beta</a>
             </li>
             <li>
+              <a href="/docs/providers/scaleway/r/lb_certificate_beta.html">scaleway_lb_certificate_beta</a>
+            </li>
+            <li>
               <a href="/docs/providers/scaleway/r/lb_frontend_beta.html">scaleway_lb_frontend_beta</a>
             </li>
           </ul>


### PR DESCRIPTION
Fix #310

@jerome-quere the code is ready for testing, however Scaleway's current implementation presents some challenges (especially from integration tests point of view). 

When running tests, I was presented with some cryptic 400 bad request message. Rerunning it through the trace mode showed following:

```

{"name":"test-cert","letsencrypt":{"common_name":"main-domain.com","subject_alternative_name":[]}}
---------------------------------------------------------
[DEBUG] POST https://api.scaleway.com/lb/v1/regions/fr-par/lbs/76ac125b-55b9-4d88-8334-5d381d2f3758/certificates
2020/02/11 21:44:03 [DEBUG] 
--------------- Scaleway SDK RESPONSE 5 : ---------------
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 188
Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
Content-Type: application/json
Date: Tue, 11 Feb 2020 21:44:02 GMT
Server: scaleway_api
Strict-Transport-Security: max-age=63072000
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Request-Id: 16938c4a-0daa-4a44-b353-713e0707ebc2

{"details":[{"field":"dns_name","message":"main-domain.com not resolve to your Load Balancer IP 51.159.25.61","reason":"constraint"}],"message":"Invalid parameters","type":"invalid_field"}
```
Error returned in INFO mode
```
[DEBUG] GET https://api.scaleway.com/lb/v1/regions/fr-par/lbs/087e832f-ce1a-48a5-aac0-4bad1b2b181b
--- FAIL: TestAccScalewayLbCertificateBeta (10.09s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: scaleway-sdk-go: http error 400 Bad Request: invalid parameters
        
          on /tmp/tf-test031039100/main.tf line 6:
          (source code not available)
        
        
FAIL
```
There are several issues:
1) The actual error message is buried, client is presented with invalid parameter/field and the only way to understand on TF level that the issue is DNS related is to parse rawbody property (not really ideal). 
2) We do not know in advance our load-balancer's ip, so we cannot have a dns pointing to it and create a certificate. In theory, if client is  able to manage our dns with the same tf stack, it would be possible to create a proper chain by using depends_on (LB->domain->cert), but even then, I would be concerned about the race condition (dns is created on the nameserver, but when scw checks for it, it fails due to propagation issues). 
3) I can't see a good way to create integration test since it won't accept invalid domain names, and we need valid ones in order to create a cert. 
4) I've not tested it yet, but does it mean that we cannot have wildcard letsencrypt certificate?
