### PR TITLE
chore: linting error

### DIFF
--- a/scaleway/resource_instance_security_group.go
+++ b/scaleway/resource_instance_security_group.go
@@ -143,8 +143,8 @@ func resourceScalewayInstanceSecurityGroupRead(d *schema.ResourceData, m interfa
 		if err != nil {
 			return err
 		}
-		d.Set("inbound_rule", inboundRules)
-		d.Set("outbound_rule", outboundRules)
+		_ = d.Set("inbound_rule", inboundRules)
+		_ = d.Set("outbound_rule", outboundRules)
 	}
 	return nil
 }

--- a/scaleway/resource_instance_security_group_rules.go
+++ b/scaleway/resource_instance_security_group_rules.go
@@ -44,7 +44,7 @@ func customImporterState(d *schema.ResourceData, m interface{}) ([]*schema.Resou
 	// It should be a SecurityGroupZonedID.
 	importZonedID := d.Id()
 
-	d.Set("security_group_id", importZonedID)
+	_ = d.Set("security_group_id", importZonedID)
 	d.SetId(importZonedID)
 
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
Fixes
```go
scaleway/resource_instance_security_group_rules.go:68:7: Error return value of `d.Set` is not checked (errcheck)
	d.Set("security_group_id", securityGroupZonedID)
	     ^
scaleway/resource_instance_security_group_rules.go:75:7: Error return value of `d.Set` is not checked (errcheck)
	d.Set("inbound_rule", inboundRules)
	     ^
scaleway/resource_instance_security_group_rules.go:76:7: Error return value of `d.Set` is not checked (errcheck)
	d.Set("outbound_rule", outboundRules)
```