### PR TITLE
doc(lb): add ACL documentation

### DIFF
--- a/scaleway/resource_lb_frontend_beta.go
+++ b/scaleway/resource_lb_frontend_beta.go
@@ -71,12 +71,12 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
-							Description: "The name of ACL",
+							Description: "The ACL name",
 						},
 						"action": {
 							Type:        schema.TypeList,
 							Required:    true,
-							Description: "Action to undertake",
+							Description: "Action to undertake when an ACL filter matches",
 							MaxItems:    1,
 							MinItems:    1,
 							Elem: &schema.Resource{
@@ -88,7 +88,7 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 											lb.ACLActionTypeAllow.String(),
 											lb.ACLActionTypeDeny.String(),
 										}, false),
-										Description: "<allow> or <deny> request",
+										Description: "The action type",
 									},
 								},
 							},
@@ -98,7 +98,7 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 							Required:    true,
 							MaxItems:    1,
 							MinItems:    1,
-							Description: "AclMatch Rule",
+							Description: "The ACL match rule",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"ip_subnet": {
@@ -106,9 +106,8 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},
-										Optional: true,
-										Description: "This is the source IP v4/v6 address of the client of the session to match or not. " +
-											"Addresses values can be specified either as plain addresses or with a netmask appended.",
+										Optional:    true,
+										Description: "A list of IPs or CIDR v4/v6 addresses of the client of the session to match",
 									},
 									"http_filter": {
 										Type:     schema.TypeString,
@@ -120,12 +119,12 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 											lb.ACLHTTPFilterPathEnd.String(),
 											lb.ACLHTTPFilterRegex.String(),
 										}, false),
-										Description: "Http filter (if backend have a HTTP forward protocol)",
+										Description: "The HTTP filter to match",
 									},
 									"http_filter_value": {
 										Type:        schema.TypeList,
 										Optional:    true,
-										Description: "Http filter value",
+										Description: "A list of possible values to match for the given HTTP filter",
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 										},
@@ -133,7 +132,7 @@ func resourceScalewayLbFrontendBeta() *schema.Resource {
 									"invert": {
 										Type:        schema.TypeBool,
 										Optional:    true,
-										Description: "If true, then condition is unless type",
+										Description: `If set to true, the condition will be of type "unless"`,
 									},
 								},
 							},

--- a/website/docs/r/lb_frontend_beta.html.markdown
+++ b/website/docs/r/lb_frontend_beta.html.markdown
@@ -33,7 +33,7 @@ resource scaleway_lb_frontend_beta frontend01 {
     name = "frontend01"
     inbound_port = "80"
 
-    # Deny downstream requests from: 192.168.0.1, 192.168.0.2 or 192.168.10.0/24
+    # Allow downstream requests from: 192.168.0.1, 192.168.0.2 or 192.168.10.0/24
     acl {
         name = "blacklist wellknwon IPs"
         action {

--- a/website/docs/r/lb_frontend_beta.html.markdown
+++ b/website/docs/r/lb_frontend_beta.html.markdown
@@ -28,20 +28,47 @@ resource "scaleway_lb_frontend_beta" "frontend01" {
 
 The following arguments are supported:
 
-- `lb_id`                       - (Required) The load-balancer ID this frontend is attached to.
-- `backend_id`                  - (Required) The load-balancer backend ID this frontend is attached to.
+- `lb_id` - (Required) The load-balancer ID this frontend is attached to.
+
+- `backend_id` - (Required) The load-balancer backend ID this frontend is attached to.
+
 ~> **Important:** Updates to `lb_id` or `backend_id` will recreate the frontend.
-- `inbound_port`                - (Required) TCP port to listen on the front side.
-- `name`                        - (Optional) The name of the load-balancer frontend.
-- `timeout_client`              - (Optional) Maximum inactivity time on the client side. (e.g.: `1s`)
-- `certificate_id`              - (Optional) Certificate ID that should be used by the frontend.
+
+- `inbound_port` - (Required) TCP port to listen on the front side.
+
+- `name` - (Optional) The name of the load-balancer frontend.
+
+- `timeout_client` - (Optional) Maximum inactivity time on the client side. (e.g.: `1s`)
+
+- `certificate_id` - (Optional) Certificate ID that should be used by the frontend.
+
+- `acl` - (Optional) A list of ACL rules to apply to the load-balancer frontend.  Defined below.
+
+## acl
+
+- `name` - (Optional) The ACL name. If not provided it will be randomly generated.
+  
+- `action` - (Required) Action to undertake when an ACL filter matches.
+  
+  - `type` - (Required) The action type. Possible values are: `allow` or `deny`.
+  
+- `match` - (Required) The ACL match rule. At least `ip_subnet` or `http_filter` and `http_filter_value` are required.
+
+  - `ip_subnet` - (Optional) A list of IPs or CIDR v4/v6 addresses of the client of the session to match.
+
+  - `http_filter` - (Optional) The HTTP filter to match. This filter is supported only if your backend protocol has an HTTP forward protocol.
+    It extracts the request's URL path, which starts at the first slash and ends before the question mark (without the host part).
+    Possible values are: `acl_http_filter_none`, `path_begin`, `path_end` or `regex`.
+
+  - `http_filter_value` - (Optional) A list of possible values to match for the given HTTP filter.
+
+  - `invert` - (Optional) If set to `true`, the condition will be of type "unless".
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The ID of the loadbalancer frontend.
-
+- `id` - The ID of the load-balancer frontend.
 
 ## Import
 

--- a/website/docs/r/lb_frontend_beta.html.markdown
+++ b/website/docs/r/lb_frontend_beta.html.markdown
@@ -28,21 +28,21 @@ resource "scaleway_lb_frontend_beta" "frontend01" {
 
 ```hcl
 resource scaleway_lb_frontend_beta frontend01 {
-	lb_id = scaleway_lb_beta.lb01.id
+    lb_id = scaleway_lb_beta.lb01.id
     backend_id = scaleway_lb_backend_beta.backend01.id
     name = "frontend01"
     inbound_port = "80"
 
     # Deny downstream requests from: 192.168.0.1, 192.168.0.2 or 192.168.10.0/24
-	acl {
-		name = "blacklist wellknwon IPs"
-		action {
-			type = "allow"
-		}
-		match {
-			ip_subnet = ["192.168.0.1", "192.168.0.2", "192.168.10.0/24"]
-		}
-	}
+    acl {
+        name = "blacklist wellknwon IPs"
+        action {
+            type = "allow"
+        }
+        match {
+            ip_subnet = ["192.168.0.1", "192.168.0.2", "192.168.10.0/24"]
+        }
+    }
 
     # Deny downstream requests from: 51.51.51.51 that match "^foo*bar$" 
     acl {
@@ -57,27 +57,27 @@ resource scaleway_lb_frontend_beta frontend01 {
     }
 
     # Allow downstream http requests that begins with "/foo" or "/bar" 
-	acl {
-		action {
-			type = "allow"
-		}
-		match {
-			http_filter = "path_begin"
-			http_filter_value = ["foo", "bar"]
-		}
-	}
+    acl {
+        action {
+            type = "allow"
+        }
+        match {
+            http_filter = "path_begin"
+            http_filter_value = ["foo", "bar"]
+        }
+    }
 
     # Allow upstream http requests that DO NOT begins with "/hi"
-	acl {
-		action {
-			type = "allow"
-		}
-		match {
-			http_filter = "path_begin"
+    acl {
+        action {
+            type = "allow"
+        }
+        match {
+            http_filter = "path_begin"
             http_filter_value = ["hi"]
             invert = "true"
-		}
-	}
+        }
+    }
 }
 ```
 

--- a/website/docs/r/lb_frontend_beta.html.markdown
+++ b/website/docs/r/lb_frontend_beta.html.markdown
@@ -18,9 +18,66 @@ Creates and manages Scaleway Load-Balancer Frontends. For more information, see 
 ```hcl
 resource "scaleway_lb_frontend_beta" "frontend01" {
     lb_id = scaleway_lb_beta.lb01.id
-    backend_id = scaleway_lb_backend_beta.bkd01.id
+    backend_id = scaleway_lb_backend_beta.backend01.id
     name = "frontend01"
     inbound_port = "80"
+}
+```
+
+## With ACLs
+
+```hcl
+resource scaleway_lb_frontend_beta frontend01 {
+	lb_id = scaleway_lb_beta.lb01.id
+    backend_id = scaleway_lb_backend_beta.backend01.id
+    name = "frontend01"
+    inbound_port = "80"
+
+    # Deny downstream requests from: 192.168.0.1, 192.168.0.2 or 192.168.10.0/24
+	acl {
+		name = "blacklist wellknwon IPs"
+		action {
+			type = "allow"
+		}
+		match {
+			ip_subnet = ["192.168.0.1", "192.168.0.2", "192.168.10.0/24"]
+		}
+	}
+
+    # Deny downstream requests from: 51.51.51.51 that match "^foo*bar$" 
+    acl {
+        action {
+            type = "deny"
+        }
+        match {
+            ip_subnet = ["51.51.51.51"]
+            http_filter = "regex"
+            http_filter_value = ["^foo*bar$"]
+        }
+    }
+
+    # Allow downstream http requests that begins with "/foo" or "/bar" 
+	acl {
+		action {
+			type = "allow"
+		}
+		match {
+			http_filter = "path_begin"
+			http_filter_value = ["foo", "bar"]
+		}
+	}
+
+    # Allow upstream http requests that DO NOT begins with "/hi"
+	acl {
+		action {
+			type = "allow"
+		}
+		match {
+			http_filter = "path_begin"
+            http_filter_value = ["hi"]
+            invert = "true"
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
Fix #419

Note that I must break `acl` into its own section as the terraform website don't support > 2 nested list values. I took inspiration with [aws/ecs_cluster](https://www.terraform.io/docs/providers/aws/r/ecs_cluster.html).