### PR TITLE
doc(README): add link to provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Terraform Provider
+Scaleway Terraform Provider
 ==================
 
-- Website: https://www.terraform.io
+- [Provider Documentation Website](https://www.terraform.io/docs/providers/scaleway/index.html)
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 


### PR DESCRIPTION
* also link to Terraform homepage seemed redundant