### PR TITLE
fix(k8s): use resource region on versions calls

### DIFF
--- a/scaleway/helpers_k8s.go
+++ b/scaleway/helpers_k8s.go
@@ -69,13 +69,15 @@ func k8sGetMinorVersionFromFull(version string) (string, error) {
 }
 
 // k8sGetLatestVersionFromMinor returns the latest full version (x.y.z) for a given minor version (x.y)
-func k8sGetLatestVersionFromMinor(k8sAPI *k8s.API, version string) (string, error) {
+func k8sGetLatestVersionFromMinor(k8sAPI *k8s.API, region scw.Region, version string) (string, error) {
 	versionSplit := strings.Split(version, ".")
 	if len(versionSplit) != 2 {
 		return "", fmt.Errorf("minor version should be like x.y not %s", version)
 	}
 
-	versionsResp, err := k8sAPI.ListVersions(&k8s.ListVersionsRequest{})
+	versionsResp, err := k8sAPI.ListVersions(&k8s.ListVersionsRequest{
+		Region: region,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/scaleway/resource_k8s_cluster_beta.go
+++ b/scaleway/resource_k8s_cluster_beta.go
@@ -439,7 +439,7 @@ func resourceScalewayK8SClusterBetaCreate(d *schema.ResourceData, m interface{})
 	}
 
 	if versionIsOnlyMinor {
-		version, err = k8sGetLatestVersionFromMinor(k8sAPI, version)
+		version, err = k8sGetLatestVersionFromMinor(k8sAPI, region, version)
 		if err != nil {
 			return err
 		}
@@ -871,7 +871,7 @@ func resourceScalewayK8SClusterBetaUpdate(d *schema.ResourceData, m interface{})
 	}
 
 	if versionIsOnlyMinor {
-		version, err = k8sGetLatestVersionFromMinor(k8sAPI, version)
+		version, err = k8sGetLatestVersionFromMinor(k8sAPI, region, version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <pcyvoct@scaleway.com>

Fixes #491 