### PR TITLE
doc(ip): fixed typo in example

### DIFF
--- a/website/docs/d/lb_ip_beta.html.markdown
+++ b/website/docs/d/lb_ip_beta.html.markdown
@@ -18,7 +18,7 @@ data "scaleway_lb_ip_beta" "my_ip" {
 }
 
 # Get info by IP ID
-data "scaleway_lb_ip_beta" "my_up" {
+data "scaleway_lb_ip_beta" "my_ip" {
   ip_id = "11111111-1111-1111-1111-111111111111"
 }
 ```


### PR DESCRIPTION
was "up", now "ip"